### PR TITLE
bump version to 0.0.42

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I already published with this changed to Adalo, but we obviously should have github reflect the correct version number.