### PR TITLE
Adds margin on button text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/TextButton/TextButton.js
+++ b/src/TextButton/TextButton.js
@@ -115,6 +115,7 @@ export default class WrappedTextButton extends Component {
 const styles = StyleSheet.create({
   text: {
     fontWeight: '600',
+    marginLeft: 4,
   },
   loading: {
     position: 'absolute',

--- a/src/TextButton/TextButton.js
+++ b/src/TextButton/TextButton.js
@@ -38,13 +38,20 @@ export default class WrappedTextButton extends Component {
   }
 
   getTextStyles() {
-    let { primaryColor, contrastColor, type } = this.props
+    let { primaryColor, contrastColor, type, icon } = this.props
+
+    const styles = {}
 
     if (type === 'contained') {
-      return { color: contrastColor }
+      styles.color = contrastColor
+    } else {
+      styles.color = primaryColor
     }
 
-    return { color: primaryColor }
+    if (icon) {
+      styles.marginLeft = 8
+    }
+    return styles
   }
 
   getAdditionalProps() {
@@ -115,7 +122,6 @@ export default class WrappedTextButton extends Component {
 const styles = StyleSheet.create({
   text: {
     fontWeight: '600',
-    marginLeft: 4,
   },
   loading: {
     position: 'absolute',


### PR DESCRIPTION
### Problem
After the horizontal card list got published, there was a weird issue with the margins on the text buttons.

### Solution
Add a margin on the text when there's an icon.

### Notes
I don't really know what went wrong, but this does work so....