### PR TITLE
Bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Changes version from 45 to 46

The version in Adalo is 46, want to make sure github reflects that.