### PR TITLE
🐞 Icon’s padding depends on whether an action is set or not

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.0.75",
+  "version": "0.1.3",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/Icon/index.js
+++ b/src/Icon/index.js
@@ -39,6 +39,7 @@ export default class WrappedIconToggle extends Component {
           maxOpacity={0.3}
           size={iconSize}
           onPress={onPress}
+          key={`iconToggle.${iconSize}`}
         />
       </View>
     )

--- a/src/Icon/index.js
+++ b/src/Icon/index.js
@@ -11,13 +11,10 @@ export default class WrappedIconToggle extends Component {
       wrapper: {
         height: iconSize,
         width: iconSize,
-        overflow: 'hidden',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
       },
-      buttonWrapper: {
-        margin: -12,
-        width: 2*iconSize,
-        height: 2*iconSize,
-      }
     }
 
     if (!onPress) {
@@ -34,7 +31,7 @@ export default class WrappedIconToggle extends Component {
     }
 
     return (
-      <View style={styles.wrapper, styles.buttonWrapper}>
+      <View style={styles.wrapper}>
         <IconToggle
           name={iconName}
           color={iconColor}


### PR DESCRIPTION
## Issue

When an action is added to an `icon` component, the height and width is doubled

## Solution

Instead of doubling the height and width, we continue using the icon's height and width and center with flex.