### PR TITLE
deleted style prop to fix bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.0.75",
+  "version": "0.0.77",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/HorizontalImageList/ImageScrollView.js
+++ b/src/HorizontalImageList/ImageScrollView.js
@@ -81,7 +81,6 @@ class ImageScrollView extends Component {
                     iconSize={iconSize}
                     gradientProps={gradientProps}
                   />
-
                   <BottomBar
                     style={bbStyles}
                     title={bottomBarText.enabled ? bottomBarText.bbTitle : ''}

--- a/src/HorizontalImageList/index.js
+++ b/src/HorizontalImageList/index.js
@@ -216,7 +216,6 @@ class HorizontalImageList extends Component {
         borderRadius: !bottomBarStyle.enabled ? imageRounding : 0,
         borderTopLeftRadius: imageRounding,
         borderTopRightRadius: imageRounding,
-        flex: 1,
       },
       rounding: {
         borderTopLeftRadius: imageRounding,


### PR DESCRIPTION
## Problem
weird spacing was occurring between the bottom bar and the image each item in the horizontal card list. This was happening when there were multiple lines of text in at least one of the imageItem's titles on the card. 

## Solution
The flex style property was causing the view surrounding the bottom bar to fill space that it didn't need to fill causing the weird spacing, so I removed the flex prop and it looks like that fixed it. 