### PR TITLE
Fix spinning when there is no action attached to button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ### Installation
-Make sure you have cloned and started [Developer Proxy](https://github.com/AdaloHQ/developer-proxy). Use your local credentials when asked while running the commands below:
+Make sure you have cloned and started [Developer Proxy](https://github.com/AdaloHQ/developer-proxy) before start. 
+
+Use your local credentials when asked while running the commands below. If you log on Adalo with another credential, you won't be able to see the new Development tab.
 
 ```sh
 $ git clone https://github.com/AdaloHQ/cli.git && cd cli && yarn && yarn link & cd ..  

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+### Installation
+Make sure you have cloned and started [Developer Proxy](https://github.com/AdaloHQ/developer-proxy). Use your local credentials when asked while running the commands below:
+
+```sh
+$ git clone https://github.com/AdaloHQ/cli.git && cd cli && yarn && yarn link & cd ..  
+$ git clone https://github.com/AdaloHQ/material-components-library.git && cd material-components-library && yarn link @adalo/cli && yarn
+$ npx adalo login --local
+$ npx adalo dev --local
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ### Installation
-Make sure you have cloned and started [Developer Proxy](https://github.com/AdaloHQ/developer-proxy) before start. 
+Make sure you have cloned and started [Developer Proxy](https://github.com/AdaloHQ/developer-proxy) before starting. 
 
 Use your local credentials when asked while running the commands below. If you log on Adalo with another credential, you won't be able to see the new Development tab.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### Installation
 Make sure you have cloned and started [Developer Proxy](https://github.com/AdaloHQ/developer-proxy) before starting. 
 
-Use your local credentials when asked while running the commands below. If you log on Adalo with another credential, you won't be able to see the new Development tab.
+Use your local credentials when asked while running the commands below. If you log into Adalo with another credential, you won't be able to see the new Development tab.
 
 ```sh
 $ git clone https://github.com/AdaloHQ/cli.git && cd cli && yarn && yarn link & cd ..  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.0.79",
+  "version": "0.1.4",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@protonapp/material-components",
   "version": "0.1.4",
-  "description": "Material UI Components for Proton",
+  "description": "Material UI Components for Adalo",
   "main": "index.js",
   "scripts": {
     "build": "proton build",

--- a/src/TextButton/TextButton.js
+++ b/src/TextButton/TextButton.js
@@ -73,6 +73,9 @@ export default class WrappedTextButton extends Component {
 
   submitAction = async () => {
     let { action } = this.props
+
+    if (!action) return null
+
     this.setState({ loading: true })
     let result = action()
     await result

--- a/src/TextButton/TextButton.js
+++ b/src/TextButton/TextButton.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Platform, View, StyleSheet, ActivityIndicator } from 'react-native'
+import { View, StyleSheet, ActivityIndicator } from 'react-native'
 import color from 'color'
 import { Button } from '@protonapp/react-native-material-ui'
 
@@ -74,11 +74,10 @@ export default class WrappedTextButton extends Component {
   submitAction = async () => {
     let { action } = this.props
 
-    if (!action) return null
-
     this.setState({ loading: true })
-    let result = action()
-    await result
+
+    await action()
+
     this.setState({ loading: false })
   }
 
@@ -88,7 +87,6 @@ export default class WrappedTextButton extends Component {
     let containerStyles = this.getContainerStyles()
     let iconStyles = this.getTextStyles()
     let textStyles = { ...this.getTextStyles() }
-    let { editor } = this.props
 
     if (icon) {
       textStyles.marginRight = 5
@@ -105,14 +103,14 @@ export default class WrappedTextButton extends Component {
             {...this.getAdditionalProps()}
             upperCase={!!upperCase}
             icon={this.state.loading ? '' : icon}
-            onPress={editor ? action : this.submitAction}
+            onPress={action && this.submitAction}
             text={this.state.loading ? '' : text}
             style={{
               container: containerStyles,
               icon: iconStyles,
               text: [textStyles, styles.text],
             }}
-            disabled={this.state.loading}
+            disabled={action ? this.state.loading : true}
           />
         </View>
         {this.state.loading && (


### PR DESCRIPTION
## Problem
Buttons inside list keep start spinning on the first click and you have to click a second time to make it work. In addition to that, they return an error message in the first click.

## Solution
add treatment when there is no action attached to the button.