### PR TITLE
Eager Update for IconToggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.1.16",
+  "version": "0.3.0",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/IconToggle/index.js
+++ b/src/IconToggle/index.js
@@ -16,7 +16,8 @@ export default (props) => {
   } = props
 
   const [localChanges, setLocalChanges] = useState([])
-  const [localValue, setLocalValue] = useState(value)
+  const localValue =
+    localChanges.length !== 0 ? localChanges[localChanges.length - 1] : value
 
   const handlePress = async () => {
     if (typeof value !== 'undefined') {
@@ -26,7 +27,6 @@ export default (props) => {
       const newValue = !localValue
       localChanges.push(newValue)
       setLocalChanges(localChanges)
-      setLocalValue(newValue)
       await onChange(newValue)
       if (activeActions && newValue) {
         await activeActions()
@@ -41,17 +41,10 @@ export default (props) => {
   }
 
   useEffect(() => {
-    if (typeof localValue === 'undefined' && typeof value !== 'undefined') {
-      setLocalValue(value)
-    }
-
     if (localChanges.length !== 0) {
       // There are local changes queued up.
       if (value === localChanges[0]) {
         localChanges.shift()
-        if (localChanges.length !== 0 && localValue !== value) {
-          setLocalValue(value)
-        }
         setLocalChanges(localChanges)
       }
     }

--- a/src/IconToggle/index.js
+++ b/src/IconToggle/index.js
@@ -41,7 +41,6 @@ export default (props) => {
   }
 
   useEffect(() => {
-    console.log('value changed. new value:', value)
     if (typeof localValue === 'undefined' && typeof value !== 'undefined') {
       setLocalValue(value)
     }
@@ -72,8 +71,8 @@ export default (props) => {
     },
   }
 
-  let iconName = localValue ? activeIcon : inactiveIcon
-  let iconColor = localValue ? activeColor : inactiveColor
+  const iconName = localValue ? activeIcon : inactiveIcon
+  const iconColor = localValue ? activeColor : inactiveColor
 
   return (
     <View style={(styles.wrapper, styles.buttonWrapper)}>

--- a/src/IconToggle/index.js
+++ b/src/IconToggle/index.js
@@ -1,66 +1,91 @@
-import React, { Component } from 'react'
+import React, { useState, useEffect } from 'react'
 import { View, StyleSheet } from 'react-native'
 import { IconToggle } from '@protonapp/react-native-material-ui'
 
-export default class WrappedIconToggle extends Component {
-  handlePress = async () => {
-    let {
-      clickActions,
-      input: { value, onChange },
-      activeActions,
-      inactiveActions,
-    } = this.props
-    await onChange(!value)
-    if (activeActions && !value) {
-      await activeActions()
-    }
-    if (inactiveActions && value) {
-      await inactiveActions()
-    }
-    if (clickActions) {
-      await clickActions()
-    }
-  }
+export default (props) => {
+  const {
+    inactiveIcon,
+    activeIcon,
+    inactiveColor,
+    activeColor,
+    toggleSize = 24,
+    clickActions,
+    input: { value, onChange },
+    activeActions,
+    inactiveActions,
+  } = props
 
-  render() {
-    let {
-      input: { value },
-      inactiveIcon,
-      activeIcon,
-      inactiveColor,
-      activeColor,
-      toggleSize
-    } = this.props
-    if (!toggleSize) toggleSize = 24
-    const styles = {
-      wrapper: {
-        height: toggleSize,
-        width: toggleSize,
-        overflow: 'hidden',
-      },
-      buttonWrapper: {
-        margin: -12,
-        width: 2*toggleSize,
-        height: 2*toggleSize,
-        overflow: 'hidden',
+  const [localChanges, setLocalChanges] = useState([])
+  const [localValue, setLocalValue] = useState(value)
+
+  const handlePress = async () => {
+    if (typeof value !== 'undefined') {
+      // Currently there's no error handling for when this onChange function errors out.
+      // TODO: Handle when it doesn't properly update. To do this, you would make a setInterval
+      // function to wait 2s (or something similar) and then check if the props did successfully change.
+      const newValue = !localValue
+      localChanges.push(newValue)
+      setLocalChanges(localChanges)
+      setLocalValue(newValue)
+      await onChange(newValue)
+      if (activeActions && newValue) {
+        await activeActions()
+      }
+      if (inactiveActions && !newValue) {
+        await inactiveActions()
+      }
+      if (clickActions) {
+        await clickActions()
       }
     }
-
-    let iconName = value ? activeIcon : inactiveIcon
-    let iconColor = value ? activeColor : inactiveColor
-
-    return (
-      <View style={styles.wrapper, styles.buttonWrapper}>
-        <IconToggle
-          name={iconName}
-          color={iconColor}
-          underlayColor={activeColor}
-          maxOpacity={0.3}
-          size={toggleSize}
-          onPress={this.handlePress}
-          key={`iconToggle.${toggleSize}`}
-        />
-      </View>
-    )
   }
+
+  useEffect(() => {
+    console.log('value changed. new value:', value)
+    if (typeof localValue === 'undefined' && typeof value !== 'undefined') {
+      setLocalValue(value)
+    }
+
+    if (localChanges.length !== 0) {
+      // There are local changes queued up.
+      if (value === localChanges[0]) {
+        localChanges.shift()
+        if (localChanges.length !== 0 && localValue !== value) {
+          setLocalValue(value)
+        }
+        setLocalChanges(localChanges)
+      }
+    }
+  }, [value])
+
+  const styles = {
+    wrapper: {
+      height: toggleSize,
+      width: toggleSize,
+      overflow: 'hidden',
+    },
+    buttonWrapper: {
+      margin: -12,
+      width: 2 * toggleSize,
+      height: 2 * toggleSize,
+      overflow: 'hidden',
+    },
+  }
+
+  let iconName = localValue ? activeIcon : inactiveIcon
+  let iconColor = localValue ? activeColor : inactiveColor
+
+  return (
+    <View style={(styles.wrapper, styles.buttonWrapper)}>
+      <IconToggle
+        name={iconName}
+        color={iconColor}
+        underlayColor={activeColor}
+        maxOpacity={0.3}
+        size={toggleSize}
+        onPress={handlePress}
+        key={`iconToggle.${toggleSize}`}
+      />
+    </View>
+  )
 }


### PR DESCRIPTION
## Problem
Currently, the `IconToggle` component does not eager update. So, when updates are slow, the component looks incredibly slow.

## Solution
Implement eager updates. Use a queue to keep track of local changes, and if there are local changes, refer to the latest change.
When props are updated, the array will knock off the front value in the queue.

## Notes
There is a bugfix inside runner that will need to be merged in before these changes are made live.

I also refactored the component to be a functional component while I was at it, should be some good code cleanup...

## Related PRs:
https://github.com/AdaloHQ/runner/pull/288