### PR TITLE
Toggle Eager Update Hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.3.0",
+  "version": "0.3.3",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/IconToggle/index.js
+++ b/src/IconToggle/index.js
@@ -20,7 +20,7 @@ export default (props) => {
     localChanges.length !== 0 ? localChanges[localChanges.length - 1] : value
 
   const handlePress = async () => {
-    if (typeof value !== 'undefined') {
+    if (onChange) {
       // Currently there's no error handling for when this onChange function errors out.
       // TODO: Handle when it doesn't properly update. To do this, you would make a setInterval
       // function to wait 2s (or something similar) and then check if the props did successfully change.


### PR DESCRIPTION
This code is already live, just hasn't been merged in yet.

This implements a hotfix to the eager updates so that values can be undefined and still changed. In certain DBs, especially external collections, `undefined` is used instead of `false` at times.