### PR TITLE
🐞 Remove `justifyContent: 'stretch'` from `ActionButton`

### DIFF
--- a/src/ActionButton/ActionButton.js
+++ b/src/ActionButton/ActionButton.js
@@ -46,7 +46,6 @@ export default class WrappedActionButton extends Component {
       flexDirection: 'row',
       alignSelf: 'stretch',
       alignItems: 'center',
-      justifyContent: 'stretch',
     }
 
     let offset = 0
@@ -66,7 +65,6 @@ export default class WrappedActionButton extends Component {
 
     const wrapperStyles = {
       alignItems: 'center',
-      justifyContent: 'stretch',
       flexDirection: 'row',
       height: 56,
       minWidth: 56,

--- a/src/ActionButton/ActionButton.js
+++ b/src/ActionButton/ActionButton.js
@@ -71,11 +71,6 @@ export default class WrappedActionButton extends Component {
       right: offset,
     }
 
-    if (Platform.OS === 'ios' || Platform.OS === 'android') {
-      delete containerStyles.justifyContent
-      delete wrapperStyles.justifyContent
-    }
-
     let labelStyles = {}
     if (this.props.styles && this.props.styles.text) {
       labelStyles = {


### PR DESCRIPTION
## Issue

`justifyContent: 'stretch'` is not supported in `react-native` and is giving a console error (no crashes). I believe these errors only show while in development as well, no production builds should show these errors.

Here are the available values for `justifyContent` in react-native: https://reactnative.dev/docs/flexbox#justify-content

## Solution

- remove `justifyContent: 'stretch'`

## Additional Notes

Have been seeing this console error in non-adalo org apps while working on a feature. 