### PR TITLE
Refactor `IconToggle` back to class Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.5.8",
+  "version": "0.7.4",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/IconToggle/index.js
+++ b/src/IconToggle/index.js
@@ -1,89 +1,120 @@
 import React, { useState, useEffect } from 'react'
 import { View, StyleSheet } from 'react-native'
-import { IconToggle } from '@protonapp/react-native-material-ui'
+import { IconToggle as ProtonIconToggle } from '@protonapp/react-native-material-ui'
 
-export default (props) => {
-  const {
-    activeIcon,
-    activeColor,
-    toggleSize = 24,
-    clickActions,
-    input: { value, onChange },
-    activeActions,
-    inactiveActions,
-  } = props
-
-  let { inactiveIcon, inactiveColor } = props
-
-  if (!inactiveIcon) {
-    inactiveIcon = 'check-box-outline-blank'
+class IconToggle extends React.Component {
+  state = {
+    localChanges: [],
   }
 
-  if (!inactiveColor) {
-    inactiveColor = '#bbb'
-  }
+  componentDidUpdate(prevProps, prevState) {
+    const { input } = this.props
 
-  const [localChanges, setLocalChanges] = useState([])
-  const localValue =
-    localChanges.length !== 0 ? localChanges[localChanges.length - 1] : value
-
-  const handlePress = async () => {
-    if (onChange) {
-      // Currently there's no error handling for when this onChange function errors out.
-      // TODO: Handle when it doesn't properly update. To do this, you would make a setInterval
-      // function to wait 2s (or something similar) and then check if the props did successfully change.
-      const newValue = !localValue
-      localChanges.push(newValue)
-      setLocalChanges(localChanges)
-      await onChange(newValue)
-      if (activeActions && newValue) {
-        await activeActions()
-      }
-      if (inactiveActions && !newValue) {
-        await inactiveActions()
-      }
-      if (clickActions) {
-        await clickActions()
-      }
+    if (prevProps.input.value !== input.value) {
+      this.handleLocalValue()
     }
   }
 
-  useEffect(() => {
+  getLocalValue = () => {
+    const { localChanges } = this.state
+    const { input } = this.props
+
+    return localChanges.length !== 0
+      ? localChanges[localChanges.length - 1]
+      : input.value
+  }
+
+  handleLocalValue = () => {
+    let { localChanges } = this.state
+    const { input } = this.props
+
     if (localChanges.length !== 0) {
-      // There are local changes queued up.
-      if (!!value === localChanges[0]) {
+      if (!!input.value !== localChanges[0]) {
+        // remove first item from array
         localChanges.shift()
-        setLocalChanges(localChanges)
+
+        this.setState((state) => ({
+          ...state,
+          localChanges,
+        }))
       }
     }
-  }, [value])
-
-  const styles = {
-    wrapper: {
-      height: toggleSize,
-      width: toggleSize,
-    },
-    buttonWrapper: {
-      margin: -12,
-      width: 2 * toggleSize,
-      height: 2 * toggleSize,
-    },
   }
 
-  const iconName = localValue ? activeIcon : inactiveIcon
-  const iconColor = localValue ? activeColor : inactiveColor
+  handlePress = async () => {
+    const { activeActions, clickActions, inactiveActions, input } = this.props
 
-  return (
-    <View style={(styles.wrapper, styles.buttonWrapper)}>
-      <IconToggle
-        name={iconName}
-        color={iconColor}
-        underlayColor={activeColor}
-        maxOpacity={0.3}
-        size={toggleSize}
-        onPress={handlePress}
-        key={`iconToggle.${toggleSize}`}
-      />
-    </View>
-  )
+    if (input.onChange) {
+      const value = !this.getLocalValue()
+
+      // update state with new value
+      this.setState((state) => ({
+        ...state,
+        localChanges: [...state.localChanges, value],
+      }))
+
+      await input.onChange(value)
+
+      if (typeof activeActions === 'function' && value) {
+        await activeActions().catch((err) => {
+          console.error('active actions failed', err)
+        })
+      }
+
+      if (typeof inactiveActions === 'function' && !value) {
+        await inactiveActions().catch((err) => {
+          console.error('inactive actions failed', err)
+        })
+      }
+
+      if (typeof clickActions === 'function') {
+        await clickActions().catch((err) => {
+          console.error('click actions failed', err)
+        })
+      }
+    }
+  }
+
+  render() {
+    const {
+      activeColor,
+      activeIcon,
+      inactiveIcon = 'check-box-outline-blank',
+      inactiveColor = '#bbbbbb',
+      toggleSize = 24,
+    } = this.props
+
+    const styles = {
+      wrapper: {
+        height: toggleSize,
+        width: toggleSize,
+      },
+      buttonWrapper: {
+        margin: -12,
+        width: 2 * toggleSize,
+        height: 2 * toggleSize,
+      },
+    }
+
+    const localValue = this.getLocalValue()
+
+    const iconName = localValue ? activeIcon : inactiveIcon
+    const iconColor = localValue ? activeColor : inactiveColor
+
+    return (
+      <View style={[styles.wrapper, styles.buttonWrapper]}>
+        <ProtonIconToggle
+          name={iconName}
+          color={iconColor}
+          underlayColor={activeColor}
+          maxOpacity={0.3}
+          size={toggleSize}
+          onPress={this.handlePress}
+          key={`iconToggle.${toggleSize}`}
+        />
+      </View>
+    )
+  }
 }
+
+export default IconToggle

--- a/src/IconToggle/index.js
+++ b/src/IconToggle/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import { View, StyleSheet } from 'react-native'
 import { IconToggle as ProtonIconToggle } from '@protonapp/react-native-material-ui'
 


### PR DESCRIPTION
## Issue

`IconToggle` breaks the rules of hooks as we have multiple instances of `react` loaded

## Solution

Refactoring back to a class component doesn't trigger this error. Not the long term solution at all, but gets us out of the hole for moving TS and Context forward.

## Related PR

https://github.com/AdaloHQ/runner/pull/365