### PR TITLE
Image list text background overlay using fixed height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.8.5",
+  "version": "0.8.12",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/ImageList/index.js
+++ b/src/ImageList/index.js
@@ -444,7 +444,6 @@ const styles = StyleSheet.create({
     top: 0,
     left: 0,
     right: 0,
-    minHeight: 100,
   },
   textWrapper: {
     flexDirection: 'column',


### PR DESCRIPTION
## Problem
The overlay for the text seems to wayyyy larger (height) than it previously was and takes up the majority of the image.

## Solution
We remove the `min-height` property that was setted to `100px` and causing the behavior.
