### PR TITLE
Fixes crashing for simple list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.8.1",
+  "version": "0.8.3",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -74,8 +74,6 @@ export default class SimpleList extends Component {
       openAccordion,
     } = this.props
 
-    console.log('this.props:', this.props)
-
     if (!items) return <View></View>
 
     let wrap = [styles.wrapper]

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -74,6 +74,8 @@ export default class SimpleList extends Component {
       openAccordion,
     } = this.props
 
+    console.log('this.props:', this.props)
+
     if (!items) return <View></View>
 
     let wrap = [styles.wrapper]
@@ -120,8 +122,7 @@ export default class SimpleList extends Component {
       return <EmptyState {...listEmptyState}></EmptyState>
     }
 
-    let { backgroundColor, border, borderSize, borderColor, rounding, shadow } =
-      background
+    let { border } = background || {}
 
     const extraStyle = {}
 


### PR DESCRIPTION
### Problem
As part of the empty state changes, Andy accidentally introduced an obscure bug where old simple lists without a background object were crashing.

He was trying to access the object outside the if block that checks that it exists.

### Solution
Use `|| {}` to prevent the crash.

### Notes
This is so small that once someone approves I want to make it live immediately.