### PR TITLE
Checks if title and subtitle are defined before filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.8.12",
+  "version": "0.8.14",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/HorizontalImageList/ImageItem.js
+++ b/src/HorizontalImageList/ImageItem.js
@@ -15,7 +15,7 @@ import { IconToggle } from '@protonapp/react-native-material-ui'
 class ImageItem extends Component {
   renderTitle() {
     const { style, title, titleLimit } = this.props
-    if (title.length > titleLimit) {
+    if (title && title.length > titleLimit) {
       const firstLine = title.substring(0, titleLimit + 1)
       const i = firstLine.lastIndexOf(' ')
       return (

--- a/src/ImageList/index.js
+++ b/src/ImageList/index.js
@@ -124,9 +124,14 @@ export default class ImageList extends Component {
       if (!currentQuery) {
         return true
       }
-      if (itm.title.text && itm.title.text.indexOf(currentQuery) >= 0) {
+      if (
+        itm.title &&
+        itm.title.text &&
+        itm.title.text.indexOf(currentQuery) >= 0
+      ) {
         return true
       } else if (
+        itm.subtitle &&
         itm.subtitle.text &&
         itm.subtitle.text.indexOf(currentQuery) >= 0
       ) {


### PR DESCRIPTION
### Problem
Megan's app (https://app.adalo.com/apps/e788c50c-981a-43db-84ad-44251011f079/screens) was crashing when you tried to search the image list, due to `title` or `subtitle` being undefined.

### Solution
Check if they are defined before accessing its value.

### Notes
I was seeing another error in the console having to do with a similar issue in HorizontalImageList so I went ahead and cleaned that up too.

Also, the code is already live on production, I wanted to ship out the fix asap because apps were crashing.