### PR TITLE
Vertical Scrolling on a Horizontal List

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.8.18",
+  "version": "0.9.0",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/AvatarList/ImageScrollView.pwa.js
+++ b/src/AvatarList/ImageScrollView.pwa.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react'
+import { Text, View, StyleSheet, Image, ScrollView, Layout } from 'react-native'
+import ImageItem from './ImageItem.js'
+import placeholder from './holdplace.png'
+
+class ImageScrollView extends Component {
+  render() {
+    const {
+      imageList,
+      textPos,
+      cropMenu,
+      imageSize,
+      imageItemStyle,
+      borderBool,
+      edit,
+    } = this.props
+
+    return (
+      <View>
+        <ScrollView showsHorizontalScrollIndicator={false}>
+          <View style={{ flexDirection: 'row', overflow: 'auto' }}>
+            {imageList &&
+              imageList.map(({ id, image, avatarClickActions, textChild }) => (
+                <ImageItem
+                  key={id}
+                  image={edit ? placeholder : image}
+                  style={imageItemStyle}
+                  text={textChild.title}
+                  textEnabled={textChild.enabled}
+                  bottom={textPos == 1}
+                  resize={cropMenu}
+                  maxLimit={((imageSize - 30) / 170) * 21 + 6}
+                  border={borderBool}
+                  onPress={avatarClickActions}
+                />
+              ))}
+          </View>
+        </ScrollView>
+      </View>
+    )
+  }
+}
+
+export default ImageScrollView

--- a/src/AvatarList/index.js
+++ b/src/AvatarList/index.js
@@ -1,30 +1,32 @@
 import React, { Component } from 'react'
-import {
-  Text,
-  View,
-  StyleSheet,
-  Image,
-  ScrollView,
-  Platform,
-} from 'react-native'
-import ImageItem from './ImageItem.js'
-import placeholder from './holdplace.png'
+import { View, StyleSheet, Platform } from 'react-native'
 import ImageScrollViewWeb from './ImageScrollView.web.js'
 import ImageScrollViewMobile from './ImageScrollView.js'
+import ImageScrollViewPWA from './ImageScrollView.pwa.js'
 import EmptyState from '../Shared/EmptyState'
 
 class AvatarList extends Component {
   isMobileDevice = () => {
-    if (
-      Platform.OS === 'ios' ||
-      Platform.OS === 'android' ||
-      /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-        navigator.userAgent
-      )
-    ) {
+    if (Platform.OS === 'ios' || Platform.OS === 'android') {
       return true
     } else {
       return false
+    }
+  }
+
+  isPWA = () => {
+    return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+      navigator.userAgent
+    )
+  }
+
+  getScrollView = () => {
+    if (this.isMobileDevice()) {
+      return ImageScrollViewMobile
+    } else if (this.isPWA()) {
+      return ImageScrollViewPWA
+    } else {
+      return ImageScrollViewWeb
     }
   }
 
@@ -125,27 +127,7 @@ class AvatarList extends Component {
       imageItemStyle.text.fontFamily = _fonts ? _fonts.body : 'inherit'
     }
 
-    const imageScrollView = this.isMobileDevice() ? (
-      <ImageScrollViewMobile
-        imageList={imageList}
-        textPos={textPos}
-        cropMenu={cropMenu}
-        imageSize={imageSize}
-        imageItemStyle={imageItemStyle}
-        borderBool={borderBool}
-        edit={edit}
-      />
-    ) : (
-      <ImageScrollViewWeb
-        imageList={imageList}
-        textPos={textPos}
-        cropMenu={cropMenu}
-        imageSize={imageSize}
-        imageItemStyle={imageItemStyle}
-        borderBool={borderBool}
-        edit={edit}
-      />
-    )
+    const ScrollViewComponent = this.getScrollView()
 
     return (
       <View
@@ -153,7 +135,15 @@ class AvatarList extends Component {
           justifyContent: 'center',
         }}
       >
-        {imageScrollView}
+        <ScrollViewComponent
+          imageList={imageList}
+          textPos={textPos}
+          cropMenu={cropMenu}
+          imageSize={imageSize}
+          imageItemStyle={imageItemStyle}
+          borderBool={borderBool}
+          edit={edit}
+        />
       </View>
     )
   }

--- a/src/ChipList/ImageScrollView.js
+++ b/src/ChipList/ImageScrollView.js
@@ -1,37 +1,13 @@
 import React, { Component } from 'react'
-import {
-  Text,
-  View,
-  StyleSheet,
-  Image,
-  ScrollView,
-  TouchableWithoutFeedback,
-} from 'react-native'
-import ImageItem from './ImageItem.js'
+import { ScrollView } from 'react-native'
 
 class ImageScrollView extends Component {
   render() {
-    const { imageList, style, rightIcon } = this.props
+    const { children } = this.props
 
     return (
       <ScrollView horizontal={true} showsHorizontalScrollIndicator={false}>
-        <View style={{ flexDirection: 'row', justifyContent: 'flex-start' }}>
-          {imageList &&
-            imageList.map(
-              ({ clickActions, text, image, rightIcon, chipStyles }, index) => (
-                <View style={style.container} key={index}>
-                  <ImageItem
-                    image={image.image}
-                    style={style}
-                    title={text.title}
-                    imageProps={image}
-                    clickActions={clickActions}
-                    rightIcon={rightIcon}
-                  />
-                </View>
-              )
-            )}
-        </View>
+        {children}
       </ScrollView>
     )
   }

--- a/src/ChipList/ImageScrollView.pwa.js
+++ b/src/ChipList/ImageScrollView.pwa.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { ScrollView } from 'react-native'
+import { ScrollView, View } from 'react-native'
 
 class ImageScrollView extends Component {
   render() {

--- a/src/ChipList/ImageScrollView.pwa.js
+++ b/src/ChipList/ImageScrollView.pwa.js
@@ -6,10 +6,13 @@ class ImageScrollView extends Component {
     const { children } = this.props
 
     return (
-      <ScrollView horizontal={true} showsHorizontalScrollIndicator={false}>
-        {children}
+      <ScrollView showsHorizontalScrollIndicator={false}>
+        <View style={{ flexDirection: 'row', overflow: 'auto' }}>
+          {children}
+        </View>
       </ScrollView>
     )
   }
 }
+
 export default ImageScrollView

--- a/src/ChipList/ImageScrollView.web.js
+++ b/src/ChipList/ImageScrollView.web.js
@@ -6,27 +6,11 @@ import ScrollContainer from 'react-indiana-drag-scroll'
 
 class ImageScrollView extends Component {
   render() {
-    const { imageList, style, editor, rightIcon } = this.props
+    const { children } = this.props
 
     return (
       <ScrollContainer horizontal={true} vertical={false}>
-        <View style={{ flexDirection: 'row', justifyContent: 'flex-start' }}>
-          {imageList &&
-            imageList.map(
-              ({ clickActions, text, image, rightIcon, chipStyles }, index) => (
-                <View style={style.container} key={index}>
-                  <ImageItem
-                    style={style}
-                    image={editor ? placeholder : image.image}
-                    imageProps={image}
-                    title={text.title}
-                    clickActions={clickActions}
-                    rightIcon={rightIcon}
-                  />
-                </View>
-              )
-            )}
-        </View>
+        {children}
       </ScrollContainer>
     )
   }

--- a/src/ChipList/index.js
+++ b/src/ChipList/index.js
@@ -1,30 +1,34 @@
 import React, { Component } from 'react'
-import {
-  Text,
-  View,
-  StyleSheet,
-  Image,
-  ScrollView,
-  Platform,
-} from 'react-native'
+import { View, Platform } from 'react-native'
 
 import placeholder from './holdplace.png'
 import ImageScrollViewWeb from './ImageScrollView.web.js'
 import ImageScrollViewMobile from './ImageScrollView.js'
+import ImageScrollViewPWA from './ImageScrollView.pwa.js'
 import EmptyState from '../Shared/EmptyState'
 
 class ChipList extends Component {
   isMobileDevice = () => {
-    if (
-      Platform.OS === 'ios' ||
-      Platform.OS === 'android' ||
-      /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-        navigator.userAgent
-      )
-    ) {
+    if (Platform.OS === 'ios' || Platform.OS === 'android') {
       return true
     } else {
       return false
+    }
+  }
+
+  isPWA = () => {
+    return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+      navigator.userAgent
+    )
+  }
+
+  getScrollView = () => {
+    if (this.isMobileDevice()) {
+      return ImageScrollViewMobile
+    } else if (this.isPWA()) {
+      return ImageScrollViewPWA
+    } else {
+      return ImageScrollViewWeb
     }
   }
 
@@ -160,11 +164,13 @@ class ChipList extends Component {
     if (shadow) {
       style.background = { ...style.background, ...shadowStyle }
     }
-    const imageScrollView = this.isMobileDevice() ? (
+    /*const imageScrollView = this.isMobileDevice() ? (
       <ImageScrollViewMobile imageList={imageList} style={style} />
     ) : (
       <ImageScrollViewWeb imageList={imageList} editor={editor} style={style} />
-    )
+    )*/
+
+    const ImageScrollView = this.getScrollView()
 
     return (
       <View
@@ -172,7 +178,23 @@ class ChipList extends Component {
           justifyContent: 'center',
         }}
       >
-        {imageScrollView}
+        <View style={{ flexDirection: 'row', justifyContent: 'flex-start' }}>
+          {imageList &&
+            imageList.map(
+              ({ clickActions, text, image, rightIcon, chipStyles }, index) => (
+                <View style={style.container} key={index}>
+                  <ImageItem
+                    style={style}
+                    image={editor ? placeholder : image.image}
+                    imageProps={image}
+                    title={text.title}
+                    clickActions={clickActions}
+                    rightIcon={rightIcon}
+                  />
+                </View>
+              )
+            )}
+        </View>
       </View>
     )
   }

--- a/src/ChipList/index.js
+++ b/src/ChipList/index.js
@@ -5,6 +5,7 @@ import placeholder from './holdplace.png'
 import ImageScrollViewWeb from './ImageScrollView.web.js'
 import ImageScrollViewMobile from './ImageScrollView.js'
 import ImageScrollViewPWA from './ImageScrollView.pwa.js'
+import ImageItem from './ImageItem'
 import EmptyState from '../Shared/EmptyState'
 
 class ChipList extends Component {
@@ -178,23 +179,28 @@ class ChipList extends Component {
           justifyContent: 'center',
         }}
       >
-        <View style={{ flexDirection: 'row', justifyContent: 'flex-start' }}>
-          {imageList &&
-            imageList.map(
-              ({ clickActions, text, image, rightIcon, chipStyles }, index) => (
-                <View style={style.container} key={index}>
-                  <ImageItem
-                    style={style}
-                    image={editor ? placeholder : image.image}
-                    imageProps={image}
-                    title={text.title}
-                    clickActions={clickActions}
-                    rightIcon={rightIcon}
-                  />
-                </View>
-              )
-            )}
-        </View>
+        <ImageScrollView>
+          <View style={{ flexDirection: 'row', justifyContent: 'flex-start' }}>
+            {imageList &&
+              imageList.map(
+                (
+                  { clickActions, text, image, rightIcon, chipStyles },
+                  index
+                ) => (
+                  <View style={style.container} key={index}>
+                    <ImageItem
+                      style={style}
+                      image={editor ? placeholder : image.image}
+                      imageProps={image}
+                      title={text.title}
+                      clickActions={clickActions}
+                      rightIcon={rightIcon}
+                    />
+                  </View>
+                )
+              )}
+          </View>
+        </ImageScrollView>
       </View>
     )
   }

--- a/src/HorizontalImageList/ImageScrollView.pwa.js
+++ b/src/HorizontalImageList/ImageScrollView.pwa.js
@@ -1,0 +1,28 @@
+import React, { Component } from 'react'
+import {
+  Text,
+  View,
+  StyleSheet,
+  Image,
+  ScrollView,
+  ImageBackground,
+  TouchableWithoutFeedback,
+} from 'react-native'
+import ImageItem from './ImageItem.js'
+import BottomBar from './BottomBar.js'
+import placeholder from './holdplace.png'
+
+class ImageScrollView extends Component {
+  render() {
+    const { children } = this.props
+
+    return (
+      <ScrollView showsHorizontalScrollIndicator={false}>
+        <View style={{ flexDirection: 'row', overflow: 'auto' }}>
+          {children}
+        </View>
+      </ScrollView>
+    )
+  }
+}
+export default ImageScrollView

--- a/src/HorizontalImageList/ImageScrollView.web.js
+++ b/src/HorizontalImageList/ImageScrollView.web.js
@@ -1,116 +1,14 @@
 import React, { Component } from 'react'
-import {
-  Text,
-  View,
-  StyleSheet,
-  Image,
-  ScrollView,
-  ImageBackground,
-  TouchableWithoutFeedback,
-} from 'react-native'
-import ImageItem from './ImageItem.js'
-import BottomBar from './BottomBar.js'
-import placeholder from './holdplace.png'
+import { View } from 'react-native'
 import ScrollContainer from 'react-indiana-drag-scroll'
 
 class ImageScrollView extends Component {
   render() {
-    const {
-      imageList,
-      imageStyles,
-      bbShadow,
-      bottomBarStyle,
-      titleLimit,
-      bbTitleLimit,
-      imageRounding,
-      shadow,
-      textSwitch,
-      iconSwitches,
-      icons,
-      textPos,
-      iconColors,
-      imageSize,
-      bbStyles,
-      gradientProps,
-      iconSize,
-      editor,
-    } = this.props
+    const { children } = this.props
     return (
       <ScrollContainer horizontal={true} vertical={false}>
         <View style={{ flexDirection: 'row', justifyContent: 'flex-start' }}>
-          {imageList &&
-            imageList.map(
-              (
-                {
-                  image,
-                  clickActions,
-                  imageOverlay,
-                  bottomBarText,
-                  bottomBarButtons,
-                },
-                index
-              ) => (
-                <View style={imageStyles.view} key={index}>
-                  <View
-                    style={
-                      bbShadow && bottomBarStyle.enabled
-                        ? imageStyles.shadow
-                        : null
-                    }
-                  >
-                    <TouchableWithoutFeedback onPress={clickActions}>
-                      <View>
-                        <View>
-                          <ImageItem
-                            image={editor ? placeholder : image}
-                            style={imageStyles}
-                            onPress={clickActions}
-                            title={imageOverlay.title}
-                            subtitle={imageOverlay.subtitle}
-                            titleLimit={titleLimit}
-                            imageRounding={imageRounding}
-                            shadow={
-                              shadow && (!bbShadow || !bottomBarStyle.enabled)
-                            }
-                            textSwitch={textSwitch}
-                            iconSwitches={iconSwitches}
-                            icons={icons}
-                            textPosition={textPos}
-                            iconColors={iconColors}
-                            iconActions={[
-                              imageOverlay.tlIconActions,
-                              imageOverlay.trIconActions,
-                              imageOverlay.brIconActions,
-                              imageOverlay.blIconActions,
-                              imageOverlay.tlIconActions2,
-                              imageOverlay.blIconActions2,
-                            ]}
-                            iconSize={iconSize}
-                            gradientProps={gradientProps}
-                          />
-                        </View>
-                        <BottomBar
-                          style={bbStyles}
-                          title={
-                            bottomBarText.enabled ? bottomBarText.bbTitle : ''
-                          }
-                          subtitle={
-                            bottomBarText.enabled
-                              ? bottomBarText.bbSubtitle
-                              : ''
-                          }
-                          titleLimit={bbTitleLimit}
-                          styleSwitch={bottomBarStyle.enabled}
-                          buttonProps={bottomBarButtons}
-                          buttonSize={((imageSize - 150) / 175) * 20 + 12}
-                          editor={editor}
-                        ></BottomBar>
-                      </View>
-                    </TouchableWithoutFeedback>
-                  </View>
-                </View>
-              )
-            )}
+          {children}
         </View>
       </ScrollContainer>
     )

--- a/src/HorizontalImageList/index.js
+++ b/src/HorizontalImageList/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { View, Platform } from 'react-native'
+import { View, Platform, TouchableWithoutFeedback } from 'react-native'
 import ImageItem from './ImageItem.js'
 import BottomBar from './BottomBar.js'
 import placeholder from './holdplace.png'

--- a/src/HorizontalImageList/index.js
+++ b/src/HorizontalImageList/index.js
@@ -1,34 +1,38 @@
 import React, { Component } from 'react'
-import {
-  Text,
-  View,
-  StyleSheet,
-  Image,
-  ScrollView,
-  ImageBackground,
-  Platform,
-} from 'react-native'
+import { View, Platform } from 'react-native'
 import ImageItem from './ImageItem.js'
 import BottomBar from './BottomBar.js'
 import placeholder from './holdplace.png'
 import ImageScrollViewMobile from './ImageScrollView.js'
 import ImageScrollViewWeb from './ImageScrollView.web.js'
+import ImageScrollViewPWA from './ImageScrollView.pwa.js'
 import EmptyState from '../Shared/EmptyState'
 
 class HorizontalImageList extends Component {
   isMobileDevice = () => {
-    if (
-      Platform.OS === 'ios' ||
-      Platform.OS === 'android' ||
-      /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-        navigator.userAgent
-      )
-    ) {
+    if (Platform.OS === 'ios' || Platform.OS === 'android') {
       return true
     } else {
       return false
     }
   }
+
+  isPWA = () => {
+    return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+      navigator.userAgent
+    )
+  }
+
+  getScrollView = () => {
+    if (this.isMobileDevice()) {
+      return ImageScrollViewMobile
+    } else if (this.isPWA()) {
+      return ImageScrollViewPWA
+    } else {
+      return ImageScrollViewWeb
+    }
+  }
+
   getRGB = (str) => {
     var match = str.match(
       /rgba?\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)?(?:, ?(\d(?:\.\d?))\))?/
@@ -430,66 +434,92 @@ class HorizontalImageList extends Component {
       bbStyles.subtitle.color = bbTextColor ? bbTextColor : '#424242'
     }
 
-    const imageScrollView = this.isMobileDevice() ? (
-      <ImageScrollViewMobile
-        imageList={imageList}
-        imageStyles={imageStyles}
-        bbShadow={bbShadow}
-        bottomBarStyle={bottomBarStyle}
-        titleLimit={titleLimit}
-        bbTitleLimit={bbTitleLimit}
-        imageRounding={imageRounding}
-        shadow={shadow}
-        textSwitch={textSwitch}
-        icons={icons}
-        iconSwitches={iconSwitches}
-        textPos={textPos}
-        iconColors={iconColors}
-        imageSize={imageSize}
-        bbStyles={bbStyles}
-        gradientProps={gradientProps}
-        iconSize={iconSize}
-      ></ImageScrollViewMobile>
-    ) : (
-      <ImageScrollViewWeb
-        imageList={imageList}
-        imageStyles={imageStyles}
-        bbShadow={bbShadow}
-        bottomBarStyle={bottomBarStyle}
-        titleLimit={titleLimit}
-        bbTitleLimit={bbTitleLimit}
-        imageRounding={imageRounding}
-        shadow={shadow}
-        textSwitch={textSwitch}
-        icons={icons}
-        iconSwitches={iconSwitches}
-        textPos={textPos}
-        iconColors={iconColors}
-        imageSize={imageSize}
-        bbStyles={bbStyles}
-        gradientProps={gradientProps}
-        editor={editor}
-        iconSize={iconSize}
-      ></ImageScrollViewWeb>
-    )
+    const ScrollView = this.getScrollView()
+
     return (
       <View
         style={{
           justifyContent: 'center',
         }}
       >
-        {imageScrollView}
+        <ScrollView>
+          {imageList &&
+            imageList.map(
+              (
+                {
+                  image,
+                  clickActions,
+                  imageOverlay,
+                  bottomBarText,
+                  bottomBarButtons,
+                },
+                index
+              ) => (
+                <View style={imageStyles.view} key={index}>
+                  <View
+                    style={
+                      bbShadow && bottomBarStyle.enabled
+                        ? imageStyles.shadow
+                        : null
+                    }
+                  >
+                    <TouchableWithoutFeedback onPress={clickActions}>
+                      <View>
+                        <View>
+                          <ImageItem
+                            image={editor ? placeholder : image}
+                            style={imageStyles}
+                            onPress={clickActions}
+                            title={imageOverlay.title}
+                            subtitle={imageOverlay.subtitle}
+                            titleLimit={titleLimit}
+                            imageRounding={imageRounding}
+                            shadow={
+                              shadow && (!bbShadow || !bottomBarStyle.enabled)
+                            }
+                            textSwitch={textSwitch}
+                            iconSwitches={iconSwitches}
+                            icons={icons}
+                            textPosition={textPos}
+                            iconColors={iconColors}
+                            iconActions={[
+                              imageOverlay.tlIconActions,
+                              imageOverlay.trIconActions,
+                              imageOverlay.brIconActions,
+                              imageOverlay.blIconActions,
+                              imageOverlay.tlIconActions2,
+                              imageOverlay.blIconActions2,
+                            ]}
+                            iconSize={iconSize}
+                            gradientProps={gradientProps}
+                          />
+                        </View>
+                        <BottomBar
+                          style={bbStyles}
+                          title={
+                            bottomBarText.enabled ? bottomBarText.bbTitle : ''
+                          }
+                          subtitle={
+                            bottomBarText.enabled
+                              ? bottomBarText.bbSubtitle
+                              : ''
+                          }
+                          titleLimit={bbTitleLimit}
+                          styleSwitch={bottomBarStyle.enabled}
+                          buttonProps={bottomBarButtons}
+                          buttonSize={((imageSize - 150) / 175) * 20 + 12}
+                          editor={editor}
+                        ></BottomBar>
+                      </View>
+                    </TouchableWithoutFeedback>
+                  </View>
+                </View>
+              )
+            )}
+        </ScrollView>
       </View>
     )
   }
 }
-
-const styles = StyleSheet.create({
-  wrapper: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-})
 
 export default HorizontalImageList


### PR DESCRIPTION
## Problem
Currently on PWA, it's impossible to scroll vertically when you start the scroll on a horizontal list. 

Turns out it's a bug with react-native-web. 

## Solution
Followed a workaround [here](https://codesandbox.io/s/ywjqyoo3rz?file=/src/App.js), originally pulled from [here](https://github.com/necolas/react-native-web/issues/1042) to implement the fix for PWA specifically.

I also refactored ChipList and HorizontalImageList to reduce duplicated code in the process.

## Notes
Once approved, we'll need to publish a new version of the library.