### PR TITLE
Bugfix/image list header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {
@@ -76,7 +76,7 @@
     "react-dom": ">=16"
   },
   "devDependencies": {
-    "@adalo/cli": "^0.0.31",
+    "@adalo/cli": "0.0.31",
     "@babel/core": "^7.1.2",
     "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/preset-env": "^7.1.0",

--- a/src/ImageList/index.js
+++ b/src/ImageList/index.js
@@ -107,12 +107,30 @@ export default class ImageList extends Component {
 
   renderHeader() {
     let { listHeader } = this.props
-
+    const {
+      styles: { header },
+    } = listHeader
+    console.log('list header', listHeader)
+    console.log('header styles', header)
     if (!listHeader || !listHeader.enabled || !listHeader.header) {
       return null
     }
+
+    const headerStyles = [
+      {
+        color: header.color ? header.color : '#fff',
+        fontSize: header.fontSize ? header.fontSize : 24,
+        fontWeight: header.fontWeight ? header.fontWeight : 600,
+        textAlign: header.textAlign ? header.textAlign : 'left',
+      },
+    ]
+
+    if (header.fontFamily) {
+      headerStyles.push({ fontFamily: header.fontFamily })
+    }
+
     return (
-      <Text style={styles.header} numberOfLines={1}>
+      <Text style={headerStyles} numberOfLines={1}>
         {listHeader.header}
       </Text>
     )
@@ -430,10 +448,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     paddingLeft: 2,
-  },
-  header: {
-    fontSize: 24,
-    fontWeight: '600',
   },
   cell: {
     padding: 2,

--- a/src/ImageList/index.js
+++ b/src/ImageList/index.js
@@ -189,6 +189,7 @@ export default class ImageList extends Component {
               notFound={notFound}
               extraStyle={extraStyle}
             >
+              {this.renderHeader()}
               {this.renderGrid(newItems)}
             </SearchBarWrapper>
           </View>

--- a/src/ImageList/index.js
+++ b/src/ImageList/index.js
@@ -110,8 +110,6 @@ export default class ImageList extends Component {
     const {
       styles: { header },
     } = listHeader
-    console.log('list header', listHeader)
-    console.log('header styles', header)
     if (!listHeader || !listHeader.enabled || !listHeader.header) {
       return null
     }

--- a/src/ImageList/manifest.json
+++ b/src/ImageList/manifest.json
@@ -53,7 +53,8 @@
             "fontFamily": "@heading",
             "fontWeight": "600",
             "color": "@text",
-            "fontSize": "18"
+            "fontSize": "24",
+            "textAlignment": "left"
           }
         }
       ]


### PR DESCRIPTION
`renderHeader()` was not being called when the list is in grid layout. I added a call to `renderHeader()`.