### PR TITLE
Add Actions to the Left Section of a Simple List

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -24,8 +24,6 @@ export default class SimpleList extends Component {
   renderHeader() {
     let { listHeader, background, _fonts } = this.props
 
-    console.log(this.props)
-
     if (!listHeader || !listHeader.header || !listHeader.enabled) {
       return null
     }
@@ -253,15 +251,15 @@ class Row extends Component {
           </View>
         )
       } else {
-          return (
-            <View style={styles.iconWrapper} pointerEvents="none">
-              <Icon
-                size={24}
-                name={leftSection.icon}
-                color={leftSection.iconColor}
-              />
-            </View>
-          )
+        return (
+          <View style={styles.iconWrapper} pointerEvents="none">
+            <Icon
+              size={24}
+              name={leftSection.icon}
+              color={leftSection.iconColor}
+            />
+          </View>
+        )
       }
     }
 

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { View, Text, StyleSheet, Image, Platform } from 'react-native'
+import { View, Text, StyleSheet, Image, Platform, TouchableOpacity } from 'react-native'
 import Icon from 'react-native-vector-icons/dist/MaterialIcons'
 import { RippleFeedback, IconToggle } from '@protonapp/react-native-material-ui'
 import SearchBarWrapper from '../Shared/SearchWrapper'
@@ -23,6 +23,8 @@ export default class SimpleList extends Component {
 
   renderHeader() {
     let { listHeader, background, _fonts } = this.props
+
+    console.log(this.props)
 
     if (!listHeader || !listHeader.header || !listHeader.enabled) {
       return null
@@ -238,16 +240,29 @@ class Row extends Component {
     let source = leftSection.image
 
     if (leftSection.type === 'icon') {
-      //56
-      return (
-        <View style={styles.iconWrapper} pointerEvents="none">
-          <Icon
-            size={24}
-            name={leftSection.icon}
-            color={leftSection.iconColor}
-          />
-        </View>
-      )
+      if (leftSection.onPress) {
+        return (
+          <View style={styles.iconWrapper}>
+            <TouchableOpacity onPress={leftSection.onPress}>
+              <Icon
+                size={24}
+                name={leftSection.icon}
+                color={leftSection.iconColor}
+              />
+            </TouchableOpacity>
+          </View>
+        )
+      } else {
+          return (
+            <View style={styles.iconWrapper} pointerEvents="none">
+              <Icon
+                size={24}
+                name={leftSection.icon}
+                color={leftSection.iconColor}
+              />
+            </View>
+          )
+      }
     }
 
     if (leftSection.type === 'avatar') {
@@ -258,16 +273,32 @@ class Row extends Component {
       } else if (!editor) {
         avatarStyle.push({ marginTop: 16 })
       }
-      return (
-        <View style={styles.imageWrapper}>
-          <Image
-            resizeMode="cover"
-            source={source}
-            style={avatarStyle}
-            pointerEvents="none"
-          />
-        </View>
-      )
+
+      if (leftSection.onPress) {
+        return (
+          <View style={styles.imageWrapper}>
+            <TouchableOpacity onPress={leftSection.onPress}>
+              <Image
+                resizeMode="cover"
+                source={source}
+                style={avatarStyle}
+              />
+            </TouchableOpacity>
+          </View>
+        )
+      }
+      else {
+        return (
+          <View style={styles.imageWrapper}>
+            <Image
+              resizeMode="cover"
+              source={source}
+              style={avatarStyle}
+              pointerEvents="none"
+            />
+          </View>
+        )
+      }
     }
 
     if (leftSection.type === 'image') {
@@ -276,16 +307,33 @@ class Row extends Component {
       if (firstLine.titleLineNum > 2 || secondLine.subtitleLineNum > 2) {
         imageStyle.push({ marginTop: 18 })
       }
-      return (
-        <View style={styles.imageWrapper}>
-          <Image
-            resizeMode="cover"
-            source={source}
-            style={imageStyle}
-            pointerEvents="none"
-          />
-        </View>
-      )
+
+      if (leftSection.onPress) {
+        return (
+          <View style={styles.imageWrapper}>
+            <TouchableOpacity onPress={leftSection.onPress}>
+              <Image
+                resizeMode="cover"
+                source={source}
+                style={imageStyle}
+                pointerEvents="none"
+              />
+            </TouchableOpacity>
+          </View>
+        )
+      }
+      else {
+        return (
+          <View style={styles.imageWrapper}>
+            <Image
+              resizeMode="cover"
+              source={source}
+              style={imageStyle}
+              pointerEvents="none"
+            />
+          </View>
+        )
+      }
     }
   }
 

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -229,7 +229,7 @@ class Row extends Component {
     return false
   }
 
-  renderImageLink(styleType) {
+  renderLink(styleType) {
     const { leftSection } = this.props
     
     const source = leftSection.image
@@ -277,7 +277,7 @@ class Row extends Component {
 
       return (
         <View style={styles.iconWrapper} pointerEvents={pointerEvents}>
-          {this.renderImageLink()}
+          {this.renderLink()}
         </View>
       )
     }
@@ -293,7 +293,7 @@ class Row extends Component {
 
       return (
         <View style={styles.imageWrapper}>
-          {this.renderImageLink(avatarStyle)}
+          {this.renderLink(avatarStyle)}
         </View>
       )
     }
@@ -307,7 +307,7 @@ class Row extends Component {
 
       return (
         <View style={styles.imageWrapper}>
-          {this.renderImageLink(imageStyle)}
+          {this.renderLink(imageStyle)}
         </View>
       )
     }

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -229,38 +229,57 @@ class Row extends Component {
     return false
   }
 
+  renderImageLink(styleType) {
+    const { leftSection } = this.props
+    
+    const source = leftSection.image
+    const pointerEvents = leftSection.onPress ? "unset" : "none"
+
+    const ImageRender = (
+      <Image
+        resizeMode="cover"
+        source={source}
+        style={styleType}
+        pointerEvents={pointerEvents}
+      />
+    );
+
+    const IconRender = (
+      <Icon
+        size={24}
+        name={leftSection.icon}
+        color={leftSection.iconColor}
+      />
+    );
+
+    const renderType = leftSection.type === 'icon' ? IconRender : ImageRender
+
+    if(leftSection.onPress) {
+      return (
+        <TouchableOpacity onPress={leftSection.onPress}>
+            {renderType}
+        </TouchableOpacity>
+      )
+    }
+    else {
+      return renderType
+    }
+  }
+
   renderLeftSection() {
     let { leftSection, firstLine, secondLine, editor } = this.props
     if (!leftSection || !leftSection.enabled) {
       return null
     }
 
-    let source = leftSection.image
-
     if (leftSection.type === 'icon') {
-      if (leftSection.onPress) {
-        return (
-          <View style={styles.iconWrapper}>
-            <TouchableOpacity onPress={leftSection.onPress}>
-              <Icon
-                size={24}
-                name={leftSection.icon}
-                color={leftSection.iconColor}
-              />
-            </TouchableOpacity>
-          </View>
-        )
-      } else {
-        return (
-          <View style={styles.iconWrapper} pointerEvents="none">
-            <Icon
-              size={24}
-              name={leftSection.icon}
-              color={leftSection.iconColor}
-            />
-          </View>
-        )
-      }
+      const pointerEvents = leftSection.onPress ? "unset" : "none"
+
+      return (
+        <View style={styles.iconWrapper} pointerEvents={pointerEvents}>
+          {this.renderImageLink()}
+        </View>
+      )
     }
 
     if (leftSection.type === 'avatar') {
@@ -272,31 +291,11 @@ class Row extends Component {
         avatarStyle.push({ marginTop: 16 })
       }
 
-      if (leftSection.onPress) {
-        return (
-          <View style={styles.imageWrapper}>
-            <TouchableOpacity onPress={leftSection.onPress}>
-              <Image
-                resizeMode="cover"
-                source={source}
-                style={avatarStyle}
-              />
-            </TouchableOpacity>
-          </View>
-        )
-      }
-      else {
-        return (
-          <View style={styles.imageWrapper}>
-            <Image
-              resizeMode="cover"
-              source={source}
-              style={avatarStyle}
-              pointerEvents="none"
-            />
-          </View>
-        )
-      }
+      return (
+        <View style={styles.imageWrapper}>
+          {this.renderImageLink(avatarStyle)}
+        </View>
+      )
     }
 
     if (leftSection.type === 'image') {
@@ -306,32 +305,11 @@ class Row extends Component {
         imageStyle.push({ marginTop: 18 })
       }
 
-      if (leftSection.onPress) {
-        return (
-          <View style={styles.imageWrapper}>
-            <TouchableOpacity onPress={leftSection.onPress}>
-              <Image
-                resizeMode="cover"
-                source={source}
-                style={imageStyle}
-                pointerEvents="none"
-              />
-            </TouchableOpacity>
-          </View>
-        )
-      }
-      else {
-        return (
-          <View style={styles.imageWrapper}>
-            <Image
-              resizeMode="cover"
-              source={source}
-              style={imageStyle}
-              pointerEvents="none"
-            />
-          </View>
-        )
-      }
+      return (
+        <View style={styles.imageWrapper}>
+          {this.renderImageLink(imageStyle)}
+        </View>
+      )
     }
   }
 
@@ -376,6 +354,7 @@ class Row extends Component {
 
     return null
   }
+
   renderSubtitle() {
     let { secondLine } = this.props
     return secondLine && secondLine.enabled
@@ -623,12 +602,11 @@ const styles = StyleSheet.create({
     marginBottom: 8,
     height: 56,
     width: 56,
-    backgroundColor: '#ccc',
-    //paddingTop: '10%',
+    backgroundColor: '#ccc'
   },
   imageWrapper: {
     height: '100%',
-    justifyContent: 'flex-start',
+    justifyContent: 'flex-start'
   },
   main: {
     flex: 1,

--- a/src/SimpleList/manifest.json
+++ b/src/SimpleList/manifest.json
@@ -153,6 +153,14 @@
           "displayName": "Image",
           "type": "image",
           "enabled": { "type": ["image", "avatar"] }
+        },
+        {
+          "name": "onPress",
+          "displayName": "Click Actions",
+          "type": "action",
+          "role": "listItem",
+          "reference": "items",
+          "enabled": { "type": ["icon", "image", "avatar"] }
         }
       ]
     },


### PR DESCRIPTION
## Problem
Makers cannot add actions to the left section icon/image/avatar of simple lists but they can for the right section.

## Solution
Adds the ability to add actions to left section of simple list.
![image](https://user-images.githubusercontent.com/51417062/155007135-7e0fa0c3-61b4-4de4-bb60-9a705e849370.png)

After:
<img width="363" alt="Screen Shot 2022-02-21 at 12 05 18 PM" src="https://user-images.githubusercontent.com/51417062/155007283-56bcf4ec-886e-4889-a854-76520a27b3de.png">

## Additional Notes (optional)

- Link to [Trello](https://trello.com/c/WSahrS46/106-add-actions-to-the-left-section-of-a-simple-list)