### PR TITLE
Add Actions to the Left Section of a Simple List (with icon animation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.6",
+  "version": "0.9.8",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -245,7 +245,11 @@ class Row extends Component {
     );
 
     if(leftSection.onPress) {
-      return <TouchableOpacity onPress={leftSection.onPress}>{ImageRender}</TouchableOpacity>
+      return (
+      <TouchableOpacity onPress={leftSection.onPress}>
+          {ImageRender}
+      </TouchableOpacity>
+      )
     }
     else {
       return ImageRender

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -229,39 +229,62 @@ class Row extends Component {
     return false
   }
 
+  renderImageLink(styleType) {
+    let { leftSection } = this.props
+    
+    let source = leftSection.image
+    const pointerEvents = leftSection.onPress ? "unset" : "none"
+
+    const ImageRender = (
+      <Image
+        resizeMode="cover"
+        source={source}
+        style={styleType}
+        pointerEvents={pointerEvents}
+      />
+    );
+
+    if(leftSection.onPress) {
+      return <TouchableOpacity onPress={leftSection.onPress}>{ImageRender}</TouchableOpacity>
+    }
+    else {
+      return ImageRender
+    }
+  }
+
   renderLeftSection() {
     let { leftSection, firstLine, secondLine, editor } = this.props
     if (!leftSection || !leftSection.enabled) {
       return null
     }
 
-    let source = leftSection.image
-
     if (leftSection.type === 'icon') {
-      if (leftSection.onPress) {
-        return (
-          <View style={styles.linkIconWrapper}>
-              <IconToggle
-                name={leftSection.icon}
-                color={leftSection.iconColor}
-                underlayColor={leftSection.iconColor}
-                maxOpacity={0.3}
-                size={24}
-                onPress={leftSection.onPress}
-              />
-          </View>
-        )
-      } else {
-        return (
-          <View style={styles.iconWrapper} pointerEvents="none">
-            <Icon
-              size={24}
-              name={leftSection.icon}
-              color={leftSection.iconColor}
-            />
-          </View>
-        )
-      }
+      const iconStyle = leftSection.onPress ? styles.linkIconWrapper : styles.iconWrapper
+      const pointerEvents = leftSection.onPress ? "unset" : "none"
+
+      const IconRender = (
+        leftSection.onPress ? 
+          <IconToggle
+            name={leftSection.icon}
+            color={leftSection.iconColor}
+            underlayColor={leftSection.iconColor}
+            maxOpacity={0.3}
+            size={24}
+            onPress={leftSection.onPress}
+          />
+        : 
+          <Icon
+            size={24}
+            name={leftSection.icon}
+            color={leftSection.iconColor}
+          />
+      )
+      
+      return (
+        <View style={iconStyle} pointerEvents={pointerEvents}>
+          {IconRender}
+        </View>
+      )
     }
 
     if (leftSection.type === 'avatar') {
@@ -273,31 +296,11 @@ class Row extends Component {
         avatarStyle.push({ marginTop: 16 })
       }
 
-      if (leftSection.onPress) {
-        return (
-          <View style={styles.imageWrapper}>
-            <TouchableOpacity onPress={leftSection.onPress}>
-              <Image
-                resizeMode="cover"
-                source={source}
-                style={avatarStyle}
-              />
-            </TouchableOpacity>
-          </View>
-        )
-      }
-      else {
-        return (
-          <View style={styles.imageWrapper}>
-            <Image
-              resizeMode="cover"
-              source={source}
-              style={avatarStyle}
-              pointerEvents="none"
-            />
-          </View>
-        )
-      }
+      return (
+        <View style={styles.imageWrapper}>
+          {this.renderImageLink(avatarStyle)}
+        </View>
+      )
     }
 
     if (leftSection.type === 'image') {
@@ -307,32 +310,11 @@ class Row extends Component {
         imageStyle.push({ marginTop: 18 })
       }
 
-      if (leftSection.onPress) {
-        return (
-          <View style={styles.imageWrapper}>
-            <TouchableOpacity onPress={leftSection.onPress}>
-              <Image
-                resizeMode="cover"
-                source={source}
-                style={imageStyle}
-                pointerEvents="none"
-              />
-            </TouchableOpacity>
-          </View>
-        )
-      }
-      else {
-        return (
-          <View style={styles.imageWrapper}>
-            <Image
-              resizeMode="cover"
-              source={source}
-              style={imageStyle}
-              pointerEvents="none"
-            />
-          </View>
-        )
-      }
+      return (
+        <View style={styles.imageWrapper}>
+          {this.renderImageLink(imageStyle)}
+        </View>
+      )
     }
   }
 
@@ -377,6 +359,7 @@ class Row extends Component {
 
     return null
   }
+
   renderSubtitle() {
     let { secondLine } = this.props
     return secondLine && secondLine.enabled

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -24,8 +24,6 @@ export default class SimpleList extends Component {
   renderHeader() {
     let { listHeader, background, _fonts } = this.props
 
-    console.log(this.props)
-
     if (!listHeader || !listHeader.header || !listHeader.enabled) {
       return null
     }
@@ -253,15 +251,15 @@ class Row extends Component {
           </View>
         )
       } else {
-          return (
-            <View style={styles.iconWrapper} pointerEvents="none">
-              <Icon
-                size={24}
-                name={leftSection.icon}
-                color={leftSection.iconColor}
-              />
-            </View>
-          )
+        return (
+          <View style={styles.iconWrapper} pointerEvents="none">
+            <Icon
+              size={24}
+              name={leftSection.icon}
+              color={leftSection.iconColor}
+            />
+          </View>
+        )
       }
     }
 

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -230,7 +230,7 @@ class Row extends Component {
   }
 
   renderImageLink(styleType) {
-    let { leftSection } = this.props
+    const { leftSection } = this.props
     
     const source = leftSection.image
     const pointerEvents = leftSection.onPress ? "unset" : "none"
@@ -246,9 +246,9 @@ class Row extends Component {
 
     if(leftSection.onPress) {
       return (
-      <TouchableOpacity onPress={leftSection.onPress}>
-          {ImageRender}
-      </TouchableOpacity>
+        <TouchableOpacity onPress={leftSection.onPress}>
+            {ImageRender}
+        </TouchableOpacity>
       )
     }
     else {

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -240,14 +240,15 @@ class Row extends Component {
     if (leftSection.type === 'icon') {
       if (leftSection.onPress) {
         return (
-          <View style={styles.iconWrapper}>
-            <TouchableOpacity onPress={leftSection.onPress}>
-              <Icon
-                size={24}
+          <View style={styles.linkIconWrapper}>
+              <IconToggle
                 name={leftSection.icon}
                 color={leftSection.iconColor}
+                underlayColor={leftSection.iconColor}
+                maxOpacity={0.3}
+                size={24}
+                onPress={leftSection.onPress}
               />
-            </TouchableOpacity>
           </View>
         )
       } else {
@@ -603,11 +604,20 @@ const styles = StyleSheet.create({
     marginTop: 16,
     marginBottom: 16,
   },
+  linkIconWrapper: { 
+    flexDirection: 'column',
+    justifyContent: 'flex-center',
+    marginRight: 20,
+    marginLeft: -12
+  },
   icon: {
     width: 24,
     height: 24,
   },
-  iconWrap: { justifyContent: 'center', height: 72 },
+  iconWrap: { 
+    justifyContent: 'center', 
+    height: 72 
+  },
   avatar: {
     marginRight: 16,
     borderRadius: 20,

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { View, Text, StyleSheet, Image, Platform } from 'react-native'
+import { View, Text, StyleSheet, Image, Platform, TouchableOpacity } from 'react-native'
 import Icon from 'react-native-vector-icons/dist/MaterialIcons'
 import { RippleFeedback, IconToggle } from '@protonapp/react-native-material-ui'
 import SearchBarWrapper from '../Shared/SearchWrapper'
@@ -23,6 +23,8 @@ export default class SimpleList extends Component {
 
   renderHeader() {
     let { listHeader, background, _fonts } = this.props
+
+    console.log(this.props)
 
     if (!listHeader || !listHeader.header || !listHeader.enabled) {
       return null
@@ -238,16 +240,29 @@ class Row extends Component {
     let source = leftSection.image
 
     if (leftSection.type === 'icon') {
-      //56
-      return (
-        <View style={styles.iconWrapper} pointerEvents="none">
-          <Icon
-            size={24}
-            name={leftSection.icon}
-            color={leftSection.iconColor}
-          />
-        </View>
-      )
+      if (leftSection.onPress) {
+        return (
+          <View style={styles.iconWrapper}>
+            <TouchableOpacity onPress={leftSection.onPress}>
+              <Icon
+                size={24}
+                name={leftSection.icon}
+                color={leftSection.iconColor}
+              />
+            </TouchableOpacity>
+          </View>
+        )
+      } else {
+          return (
+            <View style={styles.iconWrapper} pointerEvents="none">
+              <Icon
+                size={24}
+                name={leftSection.icon}
+                color={leftSection.iconColor}
+              />
+            </View>
+          )
+      }
     }
 
     if (leftSection.type === 'avatar') {
@@ -258,16 +273,32 @@ class Row extends Component {
       } else if (!editor) {
         avatarStyle.push({ marginTop: 16 })
       }
-      return (
-        <View style={styles.imageWrapper}>
-          <Image
-            resizeMode="cover"
-            source={source}
-            style={avatarStyle}
-            pointerEvents="none"
-          />
-        </View>
-      )
+
+      if (leftSection.onPress) {
+        return (
+          <View style={styles.imageWrapper}>
+            <TouchableOpacity onPress={leftSection.onPress}>
+              <Image
+                resizeMode="cover"
+                source={source}
+                style={avatarStyle}
+              />
+            </TouchableOpacity>
+          </View>
+        )
+      }
+      else {
+        return (
+          <View style={styles.imageWrapper}>
+            <Image
+              resizeMode="cover"
+              source={source}
+              style={avatarStyle}
+              pointerEvents="none"
+            />
+          </View>
+        )
+      }
     }
 
     if (leftSection.type === 'image') {
@@ -276,16 +307,33 @@ class Row extends Component {
       if (firstLine.titleLineNum > 2 || secondLine.subtitleLineNum > 2) {
         imageStyle.push({ marginTop: 18 })
       }
-      return (
-        <View style={styles.imageWrapper}>
-          <Image
-            resizeMode="cover"
-            source={source}
-            style={imageStyle}
-            pointerEvents="none"
-          />
-        </View>
-      )
+
+      if (leftSection.onPress) {
+        return (
+          <View style={styles.imageWrapper}>
+            <TouchableOpacity onPress={leftSection.onPress}>
+              <Image
+                resizeMode="cover"
+                source={source}
+                style={imageStyle}
+                pointerEvents="none"
+              />
+            </TouchableOpacity>
+          </View>
+        )
+      }
+      else {
+        return (
+          <View style={styles.imageWrapper}>
+            <Image
+              resizeMode="cover"
+              source={source}
+              style={imageStyle}
+              pointerEvents="none"
+            />
+          </View>
+        )
+      }
     }
   }
 

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -232,7 +232,7 @@ class Row extends Component {
   renderImageLink(styleType) {
     let { leftSection } = this.props
     
-    let source = leftSection.image
+    const source = leftSection.image
     const pointerEvents = leftSection.onPress ? "unset" : "none"
 
     const ImageRender = (

--- a/src/SimpleList/manifest.json
+++ b/src/SimpleList/manifest.json
@@ -153,6 +153,14 @@
           "displayName": "Image",
           "type": "image",
           "enabled": { "type": ["image", "avatar"] }
+        },
+        {
+          "name": "onPress",
+          "displayName": "Click Actions",
+          "type": "action",
+          "role": "listItem",
+          "reference": "items",
+          "enabled": { "type": ["icon", "image", "avatar"] }
         }
       ]
     },


### PR DESCRIPTION
## Problem
Makers cannot add actions to the left section icon/image/avatar of simple lists but they can for the right section.

## Solution
Adds the ability to add actions to left section of simple list. **This PR contrasts with related PR [here](https://github.com/AdaloHQ/material-components-library/pull/91) because the icon link has an animation that matches the right section icon.**

![image](https://user-images.githubusercontent.com/51417062/155007135-7e0fa0c3-61b4-4de4-bb60-9a705e849370.png)

After:
<img width="363" alt="Screen Shot 2022-02-21 at 12 05 18 PM" src="https://user-images.githubusercontent.com/51417062/155007283-56bcf4ec-886e-4889-a854-76520a27b3de.png">

## Additional Notes (optional)

- Link to [Trello](https://trello.com/c/WSahrS46/106-add-actions-to-the-left-section-of-a-simple-list)