### PR TITLE
Change simple list pointer event to 'auto'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -240,7 +240,7 @@ class Row extends Component {
     const { leftSection } = this.props
 
     const source = leftSection.image
-    const pointerEvents = leftSection.onPress ? 'unset' : 'none'
+    const pointerEvents = leftSection.onPress ? 'auto' : 'none'
 
     const ImageRender = (
       <Image
@@ -272,7 +272,7 @@ class Row extends Component {
       const iconStyle = leftSection.onPress
         ? styles.linkIconWrapper
         : styles.iconWrapper
-      const pointerEvents = leftSection.onPress ? 'unset' : 'none'
+      const pointerEvents = leftSection.onPress ? 'auto' : 'none'
 
       const IconRender = leftSection.onPress ? (
         <IconToggle


### PR DESCRIPTION
Problem:
Native builds would crash when rendering a simple list with a click action on the left item, because 'unset' is not a defined value for `pointerEvents` in React Native.
<img width="383" alt="pointer-event-error" src="https://user-images.githubusercontent.com/46685700/168176636-e3e7cf3a-0d30-41c2-b929-244a2f91dd69.png">

Solution:
Change the `pointerEvents` value to 'auto' when there is an action.
