### PR TITLE
Show loading spinners for action buttons, icons, and icons inside app bars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/ActionButton/ActionButton.js
+++ b/src/ActionButton/ActionButton.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Platform, View, StyleSheet, Text, Animated } from 'react-native'
+import { Platform, View } from 'react-native'
 import { Icon } from '@protonapp/react-native-material-ui'
 import { FAB } from 'react-native-paper'
 
@@ -13,6 +13,7 @@ export default class WrappedActionButton extends Component {
 
   state = {
     width: null,
+    isLoading: false,
   }
 
   handleLayout = ({
@@ -23,6 +24,24 @@ export default class WrappedActionButton extends Component {
     if (this.state.width !== width) {
       this.setState({ width })
     }
+  }
+
+  clickAction = async () => {
+    const { action } = this.props
+
+    if (!action) {
+      return
+    }
+
+    this.setState({
+      isLoading: true,
+    })
+
+    await action()
+
+    this.setState({
+      isLoading: false,
+    })
   }
 
   renderSub() {
@@ -37,8 +56,11 @@ export default class WrappedActionButton extends Component {
       _width,
       buttonType,
       resizeMethod,
+      getFlags,
     } = this.props
-    const { width } = this.state
+    const { width, isLoading } = this.state
+    const { hasUpdatedLoadingStates } = (getFlags && getFlags()) || {}
+    const onPressAction = hasUpdatedLoadingStates ? this.clickAction : action
 
     const containerStyles = {
       backgroundColor,
@@ -103,11 +125,12 @@ export default class WrappedActionButton extends Component {
           icon={({ size, color }) => (
             <Icon name={icon} style={{ color }} size={size}></Icon>
           )}
-          onPress={action}
+          onPress={onPressAction}
           label={breakless}
           small={false}
           animated={false}
           onLayout={this.handleLayout}
+          loading={isLoading}
         ></FAB>
       </View>
     )

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -20,7 +20,7 @@ import '../Shared/icons'
 
 export default class AppBar extends Component {
   state = {
-    loadingComponents: new Set(),
+    loadingComponents: new Set(), // allows for multiple icons to have independent loading states
   }
 
   static defaultProps = {

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -6,6 +6,7 @@ import {
   Image,
   ImageBackground,
   Text,
+  ActivityIndicator,
 } from 'react-native'
 import { Toolbar } from '@protonapp/react-native-material-ui'
 import Icon from 'react-native-vector-icons/MaterialIcons'
@@ -18,6 +19,10 @@ import IconToggleEditor from '../Shared/IconToggleEditor'
 import '../Shared/icons'
 
 export default class AppBar extends Component {
+  state = {
+    loadingComponents: new Set(),
+  }
+
   static defaultProps = {
     title: {},
     leftIcon: {},
@@ -93,25 +98,66 @@ export default class AppBar extends Component {
     return {}
   }
 
+  iconClickAction = (action, propName) => async () => {
+    if (!action) {
+      return
+    }
+
+    this.setState(state => {
+      const updatedLoadingComponents = new Set(state.loadingComponents)
+      updatedLoadingComponents.add(propName)
+
+      return { loadingComponents: updatedLoadingComponents }
+    })
+
+    await action()
+
+    this.setState(state => {
+      const updatedLoadingComponents = new Set(state.loadingComponents)
+      updatedLoadingComponents.delete(propName)
+
+      return { loadingComponents: updatedLoadingComponents }
+    })
+  }
+
   renderIcon(propName) {
-    let {
+    const {
       [propName]: { icon, enabled, action, iconType },
       color,
       editor,
+      getFlags,
     } = this.props
-    if (!enabled) return null
+
+    const { loadingComponents } = this.state
+    const { hasUpdatedLoadingStates } = (getFlags && getFlags()) || {}
+
+    const onPressAction = hasUpdatedLoadingStates ? this.iconClickAction(action, propName) : action
+
+    if (!enabled) {
+      return null
+    }
 
     let iconComponent
 
-    if (iconType !== 'toggle') {
-      iconComponent = (
-        <Icon name={icon} color={color} size={24} onPress={action} />
-      )
-    } else if (editor) {
-      iconComponent = <IconToggleEditor {...this.props[propName]} />
+    if (iconType === 'toggle') {
+      if (editor) {
+        iconComponent = <IconToggleEditor {...this.props[propName]} />
+      } else {
+        iconComponent = <WrappedIconToggle {...this.props[propName]} />
+      }
+    } else if (loadingComponents.has(propName)) {
+      iconComponent = <ActivityIndicator size="small" color={color} />
     } else {
-      iconComponent = <WrappedIconToggle {...this.props[propName]} />
+      iconComponent = (
+        <Icon
+          name={icon}
+          color={color}
+          size={24}
+          onPress={onPressAction}
+        />
+      )
     }
+
     return <View style={styles.icon}>{iconComponent}</View>
   }
   renderLogo() {

--- a/src/Icon/index.js
+++ b/src/Icon/index.js
@@ -1,13 +1,38 @@
 import React, { Component } from 'react'
-import { View, StyleSheet } from 'react-native'
+import { View, ActivityIndicator, Platform } from 'react-native'
 import { Icon, IconToggle } from '@protonapp/react-native-material-ui'
 
 import '../Shared/iconLoader'
 
 export default class WrappedIconToggle extends Component {
+  state = {
+    isLoading: false,
+  }
+
+  clickAction = async () => {
+    const { onPress } = this.props
+
+    if (!onPress) {
+      return
+    }
+
+    this.setState({
+      isLoading: true,
+    })
+
+    await onPress()
+
+    this.setState({
+      isLoading: false,
+    })
+  }
+
+
+
   render() {
-    let { iconName, iconColor, onPress, iconSize } = this.props
-    if (!iconSize) iconSize = 24
+    const { iconName, iconColor, onPress, iconSize = 24, getFlags } = this.props
+    const { isLoading } = this.state
+    const { hasUpdatedLoadingStates } = (getFlags && getFlags()) || {}
 
     const styles = {
       wrapper: {
@@ -32,6 +57,27 @@ export default class WrappedIconToggle extends Component {
       )
     }
 
+    const onPressAction = hasUpdatedLoadingStates ? this.clickAction : onPress
+
+    if (isLoading) {
+      let spinnerSize = 'small'
+
+      if (iconSize > 40) {
+        spinnerSize = 'large'
+      }
+
+      // a number is a valid size value for Android devices
+      if (Platform.OS === 'android') {
+        spinnerSize = iconSize
+      }
+
+      return (
+        <View style={styles.wrapper}>
+          <ActivityIndicator size={spinnerSize} color={iconColor} />
+        </View>
+      )
+    }
+
     return (
       <View style={styles.wrapper}>
         <IconToggle
@@ -40,7 +86,7 @@ export default class WrappedIconToggle extends Component {
           underlayColor={iconColor}
           maxOpacity={0.3}
           size={iconSize}
-          onPress={onPress}
+          onPress={onPressAction}
           key={`iconToggle.${iconSize}`}
         />
       </View>


### PR DESCRIPTION
We want to show loading spinners for buttons. We currently only have a loading state for a regular button. This PR adds loading states for:
- Action Buttons
- Icon Buttons
- Icons Buttons inside the App Bar

We will not have loading states for Icon Toggles or Toggle-type Icon Buttons inside the App Bar.

This leaves only Icon Buttons inside the Tab Bar component, which will be dealt with separately.