### PR TITLE
Pass in a loading state to bottom navigation component

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "style-loader": "^0.23.1"
   },
   "dependencies": {
-    "@protonapp/react-native-material-ui": "^2.0.6",
+    "@protonapp/react-native-material-ui": "^2.0.7",
     "chroma-js": "^2.1.2",
     "color": "^3.1.0",
     "react-indiana-drag-scroll": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/TabNavigator/index.js
+++ b/src/TabNavigator/index.js
@@ -16,12 +16,12 @@ export default class TabNavigator extends Component {
     },
   }
 
-  handleChangeTab = (tabName) => () => {
-    let prop = this.props[tabName]
-    let action = prop && prop.action
+  handleChangeTab = tabName => async () => {
+    const prop = this.props[tabName]
+    const action = prop && prop.action
 
     if (action) {
-      action()
+      await action()
     }
   }
 
@@ -38,7 +38,8 @@ export default class TabNavigator extends Component {
   }
 
   render() {
-    let { backgroundColor, editor, activeTab, _fonts } = this.props
+    let { backgroundColor, editor, activeTab, _fonts, getFlags } = this.props
+    const { hasUpdatedLoadingStates } = (getFlags && getFlags()) || {}
 
     let enabledTabs = tabNames.filter((tabName) => {
       let tab = this.props[tabName]
@@ -67,6 +68,7 @@ export default class TabNavigator extends Component {
         >
           {enabledTabs.map((tabName) => (
             <BottomNavigation.Action
+              showLoadingState={hasUpdatedLoadingStates}
               key={tabName}
               icon={tabs[tabName].icon}
               label={tabs[tabName].label}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1788,10 +1788,10 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz#54c5a964462be3d4d78af631363c18d6fa91ac26"
 
-"@protonapp/react-native-material-ui@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@protonapp/react-native-material-ui/-/react-native-material-ui-2.0.6.tgz#280cad33f41cb6265e9d95c2e0914129c57a66cf"
-  integrity sha512-rpJ012lcazFvD+5++r3a6vNqritHHnR601CQJ2EQ6roor75Zx9bPVODgQ6eObzIMINEjGtsXYktaxg+6Oiz1RA==
+"@protonapp/react-native-material-ui@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@protonapp/react-native-material-ui/-/react-native-material-ui-2.0.7.tgz#2edf2b4792d2d119773381a07931716ac7fa674b"
+  integrity sha512-9ifSLFvmUb6EM5ph+/MsTQmq239S87szVoKpFfQ7O8MKdkRRzaxEY1T0sVStgWWPWc9VuCBBepgNWBNcfnaThg==
   dependencies:
     color "3.1.0"
     hoist-non-react-statics "^2.5.5"


### PR DESCRIPTION
We want loading states for the bottom Tab Nav component. This passes in a new prop `showLoadingState`, which was implemented in https://github.com/AdaloHQ/react-native-material-ui/pull/1. It also makes `handleChangeTab` an async function, which is awaited in `react-native-material-ui`.

<img width="474" alt="Screen Shot 2022-06-06 at 1 16 53 PM" src="https://user-images.githubusercontent.com/20466869/172221343-816b88c2-c146-4bb7-8269-3f067891ca09.png">

