### PR TITLE
Bugfix/outline style console error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/Shared/SearchWrapper.js
+++ b/src/Shared/SearchWrapper.js
@@ -223,7 +223,7 @@ const styles = StyleSheet.create({
     fontWeight: 'normal',
     ...Platform.select({
       web: {
-        outlineStyle: 'none',
+        outline: 'none',
       },
       default: {},
     }),


### PR DESCRIPTION
Changed `outlineStyle: 'none'` to `outline: 'none'` to get rid of console errors regarding `outlineStyle` not being a valid style property