### PR TITLE
Fix react-native-community/blur to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,4 +4,4 @@ set -x
 
 yarn add react-native-linear-gradient
 
-yarn add @react-native-community/blur
+yarn add @react-native-community/blur@4.0.0


### PR DESCRIPTION
Android builds are failing with version 4.1.0 of @react-native-community/blur. This fixes this dependency to version 4.0.0