### PR TITLE
Fix dynamic island top padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.20",
+  "version": "0.9.22",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "chroma-js": "^2.1.2",
     "color": "^3.1.0",
     "react-indiana-drag-scroll": "^1.7.0",
+    "react-native-device-info": "^10.3.0",
     "react-native-paper": "^4.7.2",
     "react-native-vector-icons": "^9.1.0"
   }

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -307,6 +307,13 @@ export default class AppBar extends Component {
       ...this.getBorderStyle(76, false),
       ...this.getShadowStyle(),
     }
+    console.log(`renderToolbar`,{
+      editor,
+      barType,
+      hasDynamicIsland:DeviceInfo.hasDynamicIsland(),
+      hasNotch:DeviceInfo.hasNotch(),
+    })
+
     if (!editor) {
       let marginTop = -20;
       if(DeviceInfo.hasDynamicIsland() || DeviceInfo.hasNotch()){
@@ -318,6 +325,13 @@ export default class AppBar extends Component {
         paddingTop: 50,
         ...this.getBorderStyle(106, false),
       }
+      console.log(`renderToolbar applying patch`,{
+        containerStyle, 
+        barType,
+        editor,
+        hasDynamicIsland:DeviceInfo.hasDynamicIsland(),
+        hasNotch:DeviceInfo.hasNotch(),
+      })
     }
     if (barType === 'translucent') {
       return this.renderBlur(containerStyles)

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -8,6 +8,7 @@ import {
   Text,
   ActivityIndicator,
 } from 'react-native'
+import DeviceInfo from 'react-native-device-info';
 import { Toolbar } from '@protonapp/react-native-material-ui'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import Blur from './blur'
@@ -307,11 +308,14 @@ export default class AppBar extends Component {
       ...this.getShadowStyle(),
     }
     if (!editor) {
+      let marginTop = -20;
+      if(DeviceInfo.hasDynamicIsland() || DeviceInfo.hasNotch()){
+        marginTop = -40;
+      }
       containerStyles = {
         ...containerStyles,
         height: 106,
         paddingTop: 50,
-        marginTop: -30,
         ...this.getBorderStyle(106, false),
       }
     }

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -307,15 +307,9 @@ export default class AppBar extends Component {
       ...this.getBorderStyle(76, false),
       ...this.getShadowStyle(),
     }
-    console.log(`renderToolbar`,{
-      editor,
-      barType,
-      hasDynamicIsland:DeviceInfo.hasDynamicIsland(),
-      hasNotch:DeviceInfo.hasNotch(),
-    })
 
     if (!editor) {
-      let marginTop = -20;
+      let marginTop = -30;
       if(DeviceInfo.hasDynamicIsland() || DeviceInfo.hasNotch()){
         marginTop = -40;
       }
@@ -323,15 +317,9 @@ export default class AppBar extends Component {
         ...containerStyles,
         height: 106,
         paddingTop: 50,
+        marginTop,
         ...this.getBorderStyle(106, false),
       }
-      console.log(`renderToolbar applying patch`,{
-        containerStyle, 
-        barType,
-        editor,
-        hasDynamicIsland:DeviceInfo.hasDynamicIsland(),
-        hasNotch:DeviceInfo.hasNotch(),
-      })
     }
     if (barType === 'translucent') {
       return this.renderBlur(containerStyles)

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -39,6 +39,8 @@ export default class AppBar extends Component {
     backgroundImage: {},
     translucentColor: '#fff',
     titleType: 'text',
+    hasDynamicIslandOrNotch: DeviceInfo.hasDynamicIsland() || DeviceInfo.hasNotch()
+
   }
   hexToRGBA(hex, transparency) {
     if (hex.length > 9) {
@@ -255,7 +257,12 @@ export default class AppBar extends Component {
   }
 
   renderBlur(containerStyles) {
-    let { translucentColor } = this.props
+    let { translucentColor, hasDynamicIslandOrNotch } = this.props
+    
+    const blurViewStyle = {};
+    if (hasDynamicIslandOrNotch) {
+      blurViewStyle.marginTop = -40
+    }
 
     return (
       <Blur
@@ -263,6 +270,7 @@ export default class AppBar extends Component {
         borderStyle={[this.getBorderStyle(0, false), this.getShadowStyle()]}
         borderStyleWeb={[this.getBorderStyle(0, true), this.getShadowStyle()]}
         containerStyles={containerStyles}
+        blurViewStyle={blurViewStyle}
       >
         {this.renderContent()}
       </Blur>
@@ -270,10 +278,15 @@ export default class AppBar extends Component {
   }
 
   renderImageBackgroundToolbar() {
-    let { backgroundImage } = this.props
+    let { backgroundImage, hasDynamicIslandOrNotch } = this.props
 
-    let imageStyles = [
-      styles.imageBackground,
+    let imageBackgroundStyles = styles.imageBackground;
+    if (hasDynamicIslandOrNotch) {
+      imageBackgroundStyles = { ...imageBackgroundStyles, marginTop: -40 }
+    }
+
+    const imageStyles = [
+      imageBackgroundStyles,
       this.getBorderStyle(180, false),
       this.getShadowStyle(),
     ]
@@ -298,7 +311,7 @@ export default class AppBar extends Component {
   }
 
   renderToolbar() {
-    let { barType, translucentColor, backgroundColor, editor } = this.props
+    let { barType, translucentColor, backgroundColor, editor, hasDynamicIslandOrNotch } = this.props
     let containerStyles = {
       backgroundColor,
       height: 76,
@@ -310,7 +323,7 @@ export default class AppBar extends Component {
 
     if (!editor) {
       let marginTop = -30;
-      if(DeviceInfo.hasDynamicIsland() || DeviceInfo.hasNotch()){
+      if (hasDynamicIslandOrNotch) {
         marginTop = -40;
       }
       containerStyles = {

--- a/src/AppBar/blur.android.js
+++ b/src/AppBar/blur.android.js
@@ -3,7 +3,7 @@ import { View } from 'react-native'
 import { BlurView } from '@react-native-community/blur'
 
 const BlurAndroid = (props) => {
-  const { translucentColor, containerStyles } = props
+  const { translucentColor, containerStyles, blurViewStyle = {} } = props
 
   const style = {
     backgroundColor: translucentColor,
@@ -14,6 +14,7 @@ const BlurAndroid = (props) => {
     right: 0,
     left: 0,
     top: 0,
+    ...blurViewStyle
   }
 
   const viewStyles = {

--- a/src/AppBar/blur.ios.js
+++ b/src/AppBar/blur.ios.js
@@ -3,13 +3,14 @@ import { View } from 'react-native'
 import { BlurView } from '@react-native-community/blur'
 
 const Blur = (props) => {
-  const { translucentColor, borderStyle } = props
+  const { translucentColor, borderStyle, blurViewStyle = {} } = props
 
   const style = {
     backgroundColor: translucentColor,
     height: 106,
     paddingTop: 50,
     marginTop: -30,
+    ...blurViewStyle
   }
 
   return (

--- a/src/AppBar/blur.web.js
+++ b/src/AppBar/blur.web.js
@@ -1,13 +1,15 @@
-import './styles.css'
 import { View } from 'react-native'
+import './styles.css'
+
 const Blur = (props) => {
-  const { translucentColor, borderStyle } = props
+  const { translucentColor, borderStyle, blurViewStyle } = props
   const style = {
     backgroundColor: translucentColor,
     height: 106,
     width: '100%',
     paddingTop: 50,
     marginTop: -30,
+    ...blurViewStyle,
   }
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -7974,6 +7974,11 @@ react-modal@^3.6.1:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
+react-native-device-info@^10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-10.3.0.tgz#6bab64d84d3415dd00cc446c73ec5e2e61fddbe7"
+  integrity sha512-/ziZN1sA1REbJTv5mQZ4tXggcTvSbct+u5kCaze8BmN//lbxcTvWsU6NQd4IihLt89VkbX+14IGc9sVApSxd/w==
+
 react-native-iphone-x-helper@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"


### PR DESCRIPTION
**Problem**

iOS devices with dynamic islands have a top margin showing on apps

[Adalo Forum - iPhone 14 Pro layout issue](https://forum.adalo.com/t/iphone-14-pro-layout-issue/31977/11)

**Solution**

Patch AppBar margins for devices with dynamic island and notch

**Tests to check for bug fix**

- [x] AppBar displays without top white margin on iPhone 14 Pro (dynamic island)
- [x] AppBar displays without top white margin on iPhone 14 (notch)

**Test to check for regressions**

- [x] AppBar displays without top white margin on iPhone SE (no dynamic island or notch)
- [x] Content in Screen without AppBar renders below dynamic island on iPhone 14 Pro
- [x] BottomSheetNavigation displays correctly on iPhone 14 Pro <- testing other components aren't shifting because of the AppBar fix
- [x] BottomSheetNavigation displays correctly on iPhone 14
- [x] BottomSheetNavigation displays correctly on iPhoneSE

**Screenshots**

Before fix


iPhone 14 Pro Max, AppBar with top margin
![iphone_14_pro_max_current_state](https://user-images.githubusercontent.com/9484349/214057435-f80db6bc-76dd-411b-a4e8-127fec369e0b.png)
iPhone 14, AppBar with top margin
![iphone_14_pro_current_state](https://user-images.githubusercontent.com/9484349/214057727-3e8492e5-b32f-45fc-ad29-6b6b249d89d3.png)

iPhone 14 Pro Max AppBar & BottomSheet, AppBar with top margin, no issues on BottomSheet
![iphone_14_pro_max_current_state_bottom_sheet](https://user-images.githubusercontent.com/9484349/214058008-dcfc9c5c-c9ef-43a5-b902-becc67112d66.png)


After fix

iPhone 14 Pro Max AppBar after fix
![iphone_14_pro_max_after_fix](https://user-images.githubusercontent.com/9484349/214057541-d2f86022-4207-49ca-8fa7-848e9f80fd17.png)
iPhone 14 Pro Max no AppBar & content below dynamic island after fix
![iphone_14_pro_max_after_fix_content_in_viewport](https://user-images.githubusercontent.com/9484349/214057613-5f895866-301a-4c9e-bb91-1e6479844164.png)
iPhone 14 AppBar after fix
![iphone_14_after_fix](https://user-images.githubusercontent.com/9484349/214057809-2aa8335d-6900-4e84-90a9-e725fe9d2c15.png)

iPhone SE no regressions after fix
![iphone_se_after_fix](https://user-images.githubusercontent.com/9484349/214057923-c7541f7d-cf76-46b7-9d61-73a5095d3461.png)
iPhone 14 Pro Max AppBar & BottomSheet, no regressions on BottomSheet
![iphone_14_pro_max_after_fixe_bottom_sheet](https://user-images.githubusercontent.com/9484349/214058064-28e01636-b4a2-487a-b13e-627e9782f13c.png)
