### PR TITLE
Fix ripple null children crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.37",
+  "version": "0.9.38",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.38",
+  "version": "0.9.39",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/ImageList/index.js
+++ b/src/ImageList/index.js
@@ -427,7 +427,8 @@ class Cell extends Component {
       this.setState({ shapeWidth })
 
       if (!isEditor) {
-        return null
+        // Need to return at least one child, can't return null
+        return <React.Fragment/>
       }
     }
 


### PR DESCRIPTION
From this slack thread: https://foundryplatform.slack.com/archives/C040NBFNLKW/p1686228400008559

# Problem

After the last release of `material-components-library`, image lists started crashing with an error related to the `RippleFeedback` component not supporting `null` as a children.

# Solution

Replace the `null` with a `React.Fragment` to stop `RippleFeedback` from crashing.