### PR TITLE
fix: ensure minimum of 2x device pixel ratio to help with blur

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -19,7 +19,7 @@ export const applyImgixParameters = (source, layout, imgixProps = {}) => {
   const params = {
     w: layout.width,
     h: layout.height,
-    dpr: PixelRatio.get(),
+    dpr: Math.max(PixelRatio.get(), 2),
     auto: Platform.OS === 'web' ? 'format,compress' : 'compress',
     ...(typeof imgixProps === 'object' && { ...imgixProps }),
   }


### PR DESCRIPTION
## Problem

Images appear blurry or generally of lower quality since the image performance updates.

## Solution

Load images from Imgix with a minimum device pixel ratio of 2x, e.g. given an Image component size of 100x100, load at least a 200x200 image to fill the space.

## Tests
- [ ] Added tests to cover the bug or new functionalities being added

## Additional Notes
https://foundryplatform.slack.com/archives/CL8DWS6JJ/p1686533274300919

## Related PRs
- Runner, equivalent change: https://github.com/AdaloHQ/runner/pull/738