### PR TITLE
Put card list grid items in rows

### DIFF
--- a/src/CardList/index.js
+++ b/src/CardList/index.js
@@ -65,6 +65,26 @@ export default class ImageList extends Component {
     return columns
   }
 
+  getRows(items) {
+    let columnCount = this.getColumnCount()
+    let count = Math.ceil(items.length / columnCount)
+    let rows = []
+
+    for (let i = 0; i < items.length; i += 1) {
+      const row = Math.floor(i / count)
+
+      if (!rows[row]) {
+        rows[row] = []
+      }
+
+      if (items[i]) {
+        rows[row].push(items[i])
+      }
+    }
+
+    return rows
+  }
+
   renderCell = (itm, layout, editor, _fonts, width = null) => (
     <Cell
       {...itm}
@@ -96,14 +116,20 @@ export default class ImageList extends Component {
   renderGrid(items) {
     let { layout, columnCount, editor, _fonts } = this.props
 
-    let { fullWidth } = this.state
-    let width = fullWidth / columnCount - 8
+    const rows = this.getRows(items)
+    const columnWidth = { width: `${100 / columnCount}%` }
 
     return (
       <View onLayout={this.handleLayout} style={styles.gridWrap}>
-        {items.map((itm, i) =>
-          this.renderCell(itm, layout, editor, _fonts, width)
-        )}
+        {rows.map((row, i) => (
+          <View key={i} style={styles.row}>
+            {row.map((itm) => (
+              <View style={columnWidth}>
+                {this.renderCell(itm, layout, editor, _fonts)}
+              </View>
+            ))}
+          </View>
+        ))}
       </View>
     )
   }
@@ -409,7 +435,6 @@ class Cell extends Component {
   render() {
     let {
       onPress,
-      media,
       button1,
       button2,
       icon1,
@@ -419,8 +444,6 @@ class Cell extends Component {
       _fonts,
       editor,
     } = this.props
-
-    let mediaPosition = media && media.position
 
     let cell = [styles.cell, { width }]
 
@@ -694,6 +717,12 @@ const styles = StyleSheet.create({
   column: {
     flexDirection: 'column',
     flex: 1,
+  },
+  row: {
+    flexDirection: 'row',
+    flex: 1,
+    flexBasis: '100%',
+    alignItems: 'flex-start',
   },
   cell: {
     marginLeft: 4,


### PR DESCRIPTION
## Problem
Card lists set to grid layout in responsive apps would have their height automatically collapse when they were selected in the editor.

## Solution
Give the grid layout some structure, like we do with the masonry layout. Instead of just having a list of items, create rows for those items.

## Additional Notes
There's still a problem where when you change the screen size or resize the component, the height of the items changes, but the bounding box for the card list component doesn't update until you de-select and re-select the component. This is a pre-existing issue with the card list in masonry layout, as well as the image list.
There's also a pre-existing issue with the card list in multi-column grid layout where it will flicker between showing 1 and 2 columns. We have a card for this already in the backlog.