### PR TITLE
Keep imgix props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.42",
+  "version": "0.9.44",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -15,20 +15,36 @@ export const applyImgixParameters = (source, layout, imgixProps = {}) => {
     return source
   }
 
-  const path = uri.split(/[?#]/)[0]
+  const [path, query] = uri.split(/[?#]/)
+
+  const givenParams = query && query.split('&')
+  const queryValues = {}
+
+  if (givenParams) {
+    for (const param of givenParams) {
+      if (param) {
+        const [key, value] = param.split('=')
+        queryValues[key] = value
+      }
+    }
+  }
+
   const params = {
     w: layout.width,
     h: layout.height,
     dpr: Math.max(PixelRatio.get(), 2),
     auto: Platform.OS === 'web' ? 'format,compress' : 'compress',
     ...(typeof imgixProps === 'object' && { ...imgixProps }),
+    ...queryValues,
   }
-  const queryParams = Object.keys(params).map(key => `${key}=${params[key]}`).join('&')
+  const queryParams = Object.keys(params)
+    .map((key) => `${key}=${params[key]}`)
+    .join('&')
 
   if (typeof source === 'object') {
     return {
       ...source,
-      uri: `${path}?${queryParams}`
+      uri: `${path}?${queryParams}`,
     }
   }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -38,7 +38,7 @@ export const applyImgixParameters = (source, layout, imgixProps = {}) => {
     ...queryValues,
   }
   const queryParams = Object.keys(params)
-    .map((key) => `${key}=${params[key]}`)
+    .map((key) => `${key}=${encodeURIComponent(params[key])}`)
     .join('&')
 
   if (typeof source === 'object') {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -38,7 +38,10 @@ export const applyImgixParameters = (source, layout, imgixProps = {}) => {
     ...queryValues,
   }
   const queryParams = Object.keys(params)
-    .map((key) => `${key}=${encodeURIComponent(params[key])}`)
+    .map((key) => {
+      const value = decodeParam(params[key])
+      return `${key}=${encodeURIComponent(value)}`
+    })
     .join('&')
 
   if (typeof source === 'object') {
@@ -49,4 +52,16 @@ export const applyImgixParameters = (source, layout, imgixProps = {}) => {
   }
 
   return `${path}?${queryParams}`
+}
+
+const decodeParam = (value) => {
+  let prevValue = value
+  let decodedValue = decodeURIComponent(value)
+
+  while (prevValue !== decodedValue) {
+    prevValue = decodedValue
+    decodedValue = decodeURIComponent(decodedValue)
+  }
+
+  return decodedValue
 }


### PR DESCRIPTION
## Problem
Makers cannot use their own imgix props anymore by attaching them to the URL.

## Solution
Keep imgix props passed in through the URL.