### PR TITLE
fix: lock dependencies and move from scripts to package.json

### DIFF
--- a/adalo.json
+++ b/adalo.json
@@ -53,7 +53,5 @@
     }
   ],
   "logo": "./logo.png",
-  "iosInstallScript": "./scripts/install.sh",
-  "androidInstallScript": "./scripts/install.sh",
   "webpackConfig": "./webpack.config.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {
@@ -42,10 +42,12 @@
   },
   "dependencies": {
     "@protonapp/react-native-material-ui": "^2.0.7",
+    "@react-native-community/blur": "4.0.0",
     "chroma-js": "^2.1.2",
     "color": "^3.1.0",
     "react-indiana-drag-scroll": "^1.7.0",
     "react-native-device-info": "^10.3.0",
+    "react-native-linear-gradient": "2.7.3",
     "react-native-paper": "^4.7.2",
     "react-native-vector-icons": "^9.1.0"
   }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,6 @@
 set -e
 set -x
 
-yarn add react-native-linear-gradient
+yarn add react-native-linear-gradient@2.7.3
 
 yarn add @react-native-community/blur@4.0.0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -e
-set -x
-
-yarn add react-native-linear-gradient@2.7.3
-
-yarn add @react-native-community/blur@4.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1540,6 +1540,11 @@
     prop-types "^15.5.10"
     react-native-material-design-styles "^0.2.6"
 
+"@react-native-community/blur@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/blur/-/blur-4.0.0.tgz#37ce3fc04dfd259e08cef4e2d49673ea6dc4cfbf"
+  integrity sha512-sYO+Fd/hmpLJBQkhTCpq4zXFZbJ12cPI1kB12ICg0/R89hz1qyuPWVgFwtjzdRfxfoTkqWUNjHST9GJfijSO3g==
+
 "@storybook/addon-actions@^4.0.2":
   version "4.1.18"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-4.1.18.tgz#f8eae3fef92b9f3f4d166d066e98b47377784a7b"
@@ -8167,6 +8172,11 @@ react-native-iphone-x-helper@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
   integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
+
+react-native-linear-gradient@2.7.3:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.7.3.tgz#f77b71ed7c955e033f9cba5fc8478df57953eb27"
+  integrity sha512-iyJszlZ1Ech2c+2qV+isMvvJKyoctR9ashDkhJg1/cuSF0vQaeLV1FAYTT3qW9doxChJGxVAFfYoxotH0yi3Iw==
 
 react-native-material-design-styles@^0.2.6:
   version "0.2.7"


### PR DESCRIPTION
The package `react-native-linear-gradient` published a change that turned out to break Android builds.

We weren't specifying a version when installing this dependency that meant this latest version was automatically picked up during the build process, causing builds to fail.

Note, it's not clear whether this version is an "official" breaking change or merely one that our Material Components wasn't compatible with.

The fix was to specify the version before the breaking version.

Relates to this service interruption: https://www.notion.so/2023-07-23-Android-build-failures-91230bc72fde4ddbb2bc44b2acca0c91