### PR TITLE
Revert "Tweak/bottom nav size on responsive previewer"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.47",
+  "version": "0.9.48",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.47",
+  "version": "0.9.46",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/TabNavigator/index.js
+++ b/src/TabNavigator/index.js
@@ -6,12 +6,6 @@ import {
   getTheme,
 } from '@protonapp/react-native-material-ui'
 
-const DeviceTypes = {
-  MOBILE: 'mobile',
-  TABLET: 'tablet',
-  DESKTOP: 'desktop',
-}
-
 const tabNames = ['tab0', 'tab1', 'tab2', 'tab3', 'tab4']
 
 export default class TabNavigator extends Component {
@@ -22,7 +16,7 @@ export default class TabNavigator extends Component {
     },
   }
 
-  handleChangeTab = (tabName) => async () => {
+  handleChangeTab = tabName => async () => {
     const prop = this.props[tabName]
     const action = prop && prop.action
 
@@ -44,18 +38,8 @@ export default class TabNavigator extends Component {
   }
 
   render() {
-    let {
-      backgroundColor,
-      editor,
-      activeTab,
-      _fonts,
-      getFlags,
-      isPreviewer,
-      isResponsiveComponent,
-      _deviceType,
-    } = this.props
-
-    const { hasResponsivePreviewer } = (getFlags && getFlags()) || {}
+    let { backgroundColor, editor, activeTab, _fonts, getFlags } = this.props
+    const { hasUpdatedLoadingStates } = (getFlags && getFlags()) || {}
 
     let enabledTabs = tabNames.filter((tabName) => {
       let tab = this.props[tabName]
@@ -68,24 +52,7 @@ export default class TabNavigator extends Component {
       tabs[tabName] = this.props[tabName]
     })
 
-    const getWrapperStyles = () => {
-      if (editor) {
-        return styles.editorWrapper
-      }
-
-      if (
-        isPreviewer &&
-        isResponsiveComponent &&
-        _deviceType === DeviceTypes.MOBILE &&
-        hasResponsivePreviewer
-      ) {
-        return styles.responsiveWrapper
-      }
-
-      return styles.wrapper
-    }
-
-    const wrapperStyles = getWrapperStyles()
+    let wrapperStyles = editor ? styles.editorWrapper : styles.wrapper
 
     let defaultFontStyle = _fonts
       ? { fontFamily: _fonts.body, fontSize: 11 }
@@ -101,7 +68,7 @@ export default class TabNavigator extends Component {
         >
           {enabledTabs.map((tabName) => (
             <BottomNavigation.Action
-              showLoadingState
+              showLoadingState={hasUpdatedLoadingStates}
               key={tabName}
               icon={tabs[tabName].icon}
               label={tabs[tabName].label}
@@ -121,9 +88,6 @@ export default class TabNavigator extends Component {
 }
 
 const styles = StyleSheet.create({
-  responsiveWrapper: {
-    height: 76,
-  },
   wrapper: {
     marginBottom: -100,
     paddingBottom: 100,


### PR DESCRIPTION
Reverts AdaloHQ/material-components-library#125

This is no longer needed since we're now using layout guides for the Responsive Previewer

### With layout guides
<img width="440" alt="Screenshot 2023-11-09 at 16 22 29" src="https://github.com/AdaloHQ/material-components-library/assets/28742636/feab0adf-214a-4e4b-8b3c-705914771d0a">
