### PR TITLE
Fix: Image List column rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.48",
+  "version": "0.9.49",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/ImageList/index.js
+++ b/src/ImageList/index.js
@@ -172,9 +172,15 @@ export default class ImageList extends Component {
 
     if (!items) {
       if (hasUpdatedLoadingStates) {
-        let height = columnCount === 2 ? _height / 2 : _height
+        // TODO (michael-adalo): flag is now set to ON for all environments,
+        // we could remove the check and default to the logic below
+        const height = columnCount === 2 ? _height / 2 : _height
+
         return (
-          <View style={{ height, justifyContent: 'center' }}>
+          <View
+            style={{ height, justifyContent: 'center' }}
+            onLayout={this.handleLayout}
+          >
             <ActivityIndicator color="#999999" />
           </View>
         )


### PR DESCRIPTION
## Problem

When the Image List component loads, the columns wrap.  E.g. if you selected 2 columns, it would render 1, 3 columns would render 2 and so on.

## Solution

We listen for an On Layout event to fire, enabling the component width to be set correctly, ensuring the image "cells" or columns are the correct width.

When the component first loads, the layout event does not fire.  On subsequent visits to the screen, the layout event fires and the component loads correctly (perhaps where the screen isn't rendered in the foreground?)

We briefly render a loading state which did not have a listener for layout events.   Adding the `onLayout` event to this loading state correctly sets the width of the component allowing the image "cells" to render at the correct width.

Published `0.9.49` for testing.