### PR TITLE
Fix: Simple List subtitle effect on editor bounds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.50",
+  "version": "0.9.51",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -173,6 +173,7 @@ export default class SimpleList extends Component {
                 lastRow={i === newItems.length - 1}
                 fullWidth={this.state.fullWidth}
                 editor={this.props.editor}
+                _width={this.props._width}
                 _fonts={this.props._fonts}
               />
             ))}
@@ -184,8 +185,18 @@ export default class SimpleList extends Component {
 }
 
 class Row extends Component {
+  getFullWidth() {
+    const { editor, _width } = this.props
+
+    if (editor) {
+      return _width
+    }
+
+    return this.props.fullWidth
+  }
   getWidthLimit() {
-    let { leftSection, rightSection, fullWidth } = this.props
+    let { leftSection, rightSection } = this.props
+    let fullWidth = this.getFullWidth()
     let leftSectWidth = 0
     let rightSectWidth = 0
 


### PR DESCRIPTION
## Problem

![image](https://github.com/AdaloHQ/material-components-library/assets/125075036/73cd5da6-5a92-48ad-93f2-a937292068f6)

Simple List, when configured to have 2 lines for subtitle causes it to break out of its bounds.

## Solution
<img width="561" alt="Screenshot 2024-05-08 at 17 42 06" src="https://github.com/AdaloHQ/material-components-library/assets/125075036/baa8a2d3-1ebe-4003-a4ba-109672449b66">

The component relies on onLayout to get the component width that won't fire with the SSR technique we use to render the component for the bounds calculation.  When displaying the component within Builder, we pass some extra metadata props to the component, one of which is `_width` that we can use as a fallback.