### PR TITLE
Expanded button resizing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.51",
+  "version": "0.9.52",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/TextButton/TextButton.js
+++ b/src/TextButton/TextButton.js
@@ -7,7 +7,6 @@ import '../Shared/icons'
 
 const iconSizes = [48, 32, 24, 20, 18, 16]
 const spaceSizes = [16, 12, 8, 6, 4, 2]
-// const spaceSizes = [18, 14, 10, 8, 6, 4]
 const fontSizes = [32, 24, 18, 14, 12, 10]
 
 export default class WrappedTextButton extends Component {
@@ -29,7 +28,7 @@ export default class WrappedTextButton extends Component {
     let { type, primaryColor, borderRadius, sizing, icon, text } = this.props
     const newButtonStyles = typeof sizing === 'number'
 
-    const styles = newButtonStyles
+    const containerStyles = newButtonStyles
       ? {
           paddingLeft: 2,
           paddingRight: 2,
@@ -42,7 +41,7 @@ export default class WrappedTextButton extends Component {
 
     if (type === 'contained') {
       return {
-        ...styles,
+        ...containerStyles,
         backgroundColor: primaryColor,
         borderRadius,
       }
@@ -55,14 +54,14 @@ export default class WrappedTextButton extends Component {
       let borderColor = baseColor.fade(1 - alpha).toString()
 
       return {
-        ...styles,
+        ...containerStyles,
         borderColor,
         borderWidth: 1,
         borderRadius,
       }
     }
 
-    return styles
+    return containerStyles
   }
 
   getTextStyles() {

--- a/src/TextButton/TextButton.js
+++ b/src/TextButton/TextButton.js
@@ -5,9 +5,14 @@ import { Button } from '@protonapp/react-native-material-ui'
 
 import '../Shared/icons'
 
-const iconSizes = [48, 32, 24, 20, 18, 16]
-const spaceSizes = [16, 12, 8, 6, 4, 2]
-const fontSizes = [32, 24, 18, 14, 12, 10]
+const SIZE_PROPERTIES = new Map([
+  ['gigantic', { icon: 48, space: 16, font: 32 }],
+  ['extraLarge', { icon: 32, space: 12, font: 24 }],
+  ['large', { icon: 24, space: 8, font: 18 }],
+  ['medium', { icon: 20, space: 6, font: 14 }],
+  ['small', { icon: 18, space: 4, font: 12 }],
+  ['extraSmall', { icon: 16, space: 2, font: 10 }],
+])
 
 export default class WrappedTextButton extends Component {
   _isMounted = false
@@ -26,13 +31,12 @@ export default class WrappedTextButton extends Component {
 
   getContainerStyles() {
     let { type, primaryColor, borderRadius, sizing, icon, text } = this.props
-    const newButtonStyles = typeof sizing === 'number'
 
-    const containerStyles = newButtonStyles
+    const containerStyles = SIZE_PROPERTIES.has(sizing)
       ? {
           paddingLeft: 2,
           paddingRight: 2,
-          gap: icon && text ? spaceSizes[sizing] : 0,
+          gap: icon && text ? SIZE_PROPERTIES.get(sizing).space : 0,
           justifyContent: 'center',
           alignItems: 'center',
           borderWidth: 0,
@@ -87,8 +91,8 @@ export default class WrappedTextButton extends Component {
       textStyles.marginLeft = 8
     }
 
-    if (typeof sizing === 'number') {
-      textStyles.fontSize = fontSizes[sizing]
+    if (SIZE_PROPERTIES.has(sizing)) {
+      textStyles.fontSize = SIZE_PROPERTIES.get(sizing).font
       textStyles.marginLeft = 0
       textStyles.marginRight = 0
       textStyles.paddingLeft = 0
@@ -101,8 +105,8 @@ export default class WrappedTextButton extends Component {
   getIconStyles() {
     const { sizing } = this.props
 
-    if (typeof sizing === 'number') {
-      return { fontSize: iconSizes[sizing] }
+    if (SIZE_PROPERTIES.has(sizing)) {
+      return { fontSize: SIZE_PROPERTIES.get(sizing).icon }
     }
 
     return {}
@@ -140,7 +144,7 @@ export default class WrappedTextButton extends Component {
 
   renderSub() {
     let { icon, action, text, upperCase, container, sizing } = this.props
-    const newButtonStyles = typeof sizing === 'number'
+    const newButtonStyles = SIZE_PROPERTIES.has(sizing)
 
     let containerStyles = this.getContainerStyles()
     let iconStyles = this.getTextStyles()

--- a/src/TextButton/TextButton.js
+++ b/src/TextButton/TextButton.js
@@ -5,6 +5,11 @@ import { Button } from '@protonapp/react-native-material-ui'
 
 import '../Shared/icons'
 
+const iconSizes = [48, 32, 24, 20, 18, 16]
+const spaceSizes = [16, 12, 8, 6, 4, 2]
+// const spaceSizes = [18, 14, 10, 8, 6, 4]
+const fontSizes = [32, 24, 18, 14, 12, 10]
+
 export default class WrappedTextButton extends Component {
   _isMounted = false
 
@@ -21,12 +26,26 @@ export default class WrappedTextButton extends Component {
   }
 
   getContainerStyles() {
-    let { type, primaryColor, borderRadius } = this.props
+    let { type, primaryColor, borderRadius, sizing, icon, text } = this.props
+    const newButtonStyles = typeof sizing === 'number'
 
+    const styles = newButtonStyles
+      ? {
+          paddingLeft: 2,
+          paddingRight: 2,
+          gap: icon && text ? spaceSizes[sizing] : 0,
+          justifyContent: 'center',
+          alignItems: 'center',
+          borderWidth: 0,
+        }
+      : {}
 
     if (type === 'contained') {
-
-      return { backgroundColor: primaryColor, borderRadius }
+      return {
+        ...styles,
+        backgroundColor: primaryColor,
+        borderRadius,
+      }
     }
 
     if (type === 'outlined') {
@@ -35,14 +54,20 @@ export default class WrappedTextButton extends Component {
       let alpha = saturation <= 10 ? 0.23 : 0.5
       let borderColor = baseColor.fade(1 - alpha).toString()
 
-      return { borderColor, borderWidth: 1, borderRadius }
+      return {
+        ...styles,
+        borderColor,
+        borderWidth: 1,
+        borderRadius,
+      }
     }
 
-    return {}
+    return styles
   }
 
   getTextStyles() {
-    let { primaryColor, contrastColor, type, icon, styles, _fonts } = this.props
+    let { primaryColor, contrastColor, type, icon, styles, sizing, _fonts } =
+      this.props
 
     const textStyles = { fontWeight: '600' }
 
@@ -62,7 +87,26 @@ export default class WrappedTextButton extends Component {
     if (icon) {
       textStyles.marginLeft = 8
     }
+
+    if (typeof sizing === 'number') {
+      textStyles.fontSize = fontSizes[sizing]
+      textStyles.marginLeft = 0
+      textStyles.marginRight = 0
+      textStyles.paddingLeft = 0
+      textStyles.paddingRight = 0
+    }
+
     return textStyles
+  }
+
+  getIconStyles() {
+    const { sizing } = this.props
+
+    if (typeof sizing === 'number') {
+      return { fontSize: iconSizes[sizing] }
+    }
+
+    return {}
   }
 
   getAdditionalProps() {
@@ -96,18 +140,31 @@ export default class WrappedTextButton extends Component {
   }
 
   renderSub() {
-    let { icon, action, text, upperCase, container } = this.props
+    let { icon, action, text, upperCase, container, sizing } = this.props
+    const newButtonStyles = typeof sizing === 'number'
 
     let containerStyles = this.getContainerStyles()
     let iconStyles = this.getTextStyles()
     let textStyles = { ...this.getTextStyles() }
 
-    if (icon) {
+    if (icon && !newButtonStyles) {
       textStyles.marginRight = 5
     }
 
+    if (newButtonStyles) {
+      iconStyles = { ...iconStyles, ...this.getIconStyles() }
+
+      if (!text) {
+        textStyles = {}
+      }
+    }
+
     if (upperCase) {
-      textStyles.letterSpacing = 1
+      if (newButtonStyles) {
+        textStyles.letterSpacing = 0.6
+      } else {
+        textStyles.letterSpacing = 1
+      }
     }
 
     return (
@@ -120,12 +177,15 @@ export default class WrappedTextButton extends Component {
             onPress={action && this.submitAction}
             text={this.state.loading ? '' : text}
             style={{
-              container: [containerStyles, container],
+              container: [
+                containerStyles,
+                container,
+                { height: this.props._height },
+              ],
               icon: iconStyles,
               text: [textStyles, styles.text],
             }}
             disabled={this.state.loading}
-
           />
         </View>
         {this.state.loading && (

--- a/src/TextButton/textButtonManifest.json
+++ b/src/TextButton/textButtonManifest.json
@@ -4,6 +4,7 @@
   "defaultWidth": 160,
   "defaultHeight": 36,
   "component": "./TextButton.js",
+  "resizeY": true,
   "props": [
     {
       "name": "type",
@@ -36,6 +37,23 @@
       "default": "add"
     },
     {
+      "name": "sizing",
+      "displayName": "Text & Icon Sizing",
+      "type": "number",
+      "default": 3,
+      "control": {
+        "type": "menu",
+        "options": [
+          { "label": "Gigantic", "value": 0 },
+          { "label": "Extra large", "value": 1 },
+          { "label": "Large", "value": 2 },
+          { "label": "Medium", "value": 3 },
+          { "label": "Small", "value": 4 },
+          { "label": "Extra small", "value": 5 }
+        ]
+      }
+    },
+    {
       "name": "primaryColor",
       "displayName": "Button Color",
       "type": "color",
@@ -64,7 +82,7 @@
       "name": "shadow",
       "displayName": "Shadow",
       "type": "boolean",
-      "default": true,
+      "default": false,
       "enabled": { "type": "contained" }
     },
     {

--- a/src/TextButton/textButtonManifest.json
+++ b/src/TextButton/textButtonManifest.json
@@ -40,16 +40,16 @@
       "name": "sizing",
       "displayName": "Text & Icon Sizing",
       "type": "number",
-      "default": 3,
+      "default": "medium",
       "control": {
         "type": "menu",
         "options": [
-          { "label": "Gigantic", "value": 0 },
-          { "label": "Extra large", "value": 1 },
-          { "label": "Large", "value": 2 },
-          { "label": "Medium", "value": 3 },
-          { "label": "Small", "value": 4 },
-          { "label": "Extra small", "value": 5 }
+          { "label": "Gigantic", "value": "gigantic" },
+          { "label": "Extra large", "value": "extraLarge" },
+          { "label": "Large", "value": "large" },
+          { "label": "Medium", "value": "medium" },
+          { "label": "Small", "value": "small" },
+          { "label": "Extra small", "value": "extraSmall" }
         ]
       }
     },


### PR DESCRIPTION
## Problem
We want to be able to resize buttons vertically and create some preset options for variable icon and text sizing.

## Solution
Set `resizeY` to true and added dropdown for "Text & Icon Sizing". If we don't have a value set for `sizing`, we use the old styling for the text and icon. If we do have a value for `sizing`, we use our new preset styles. Also, shadow is now off by default.

https://github.com/AdaloHQ/material-components-library/assets/46685700/bb7a3389-2279-4030-a1db-075bb97d3a40

