### PR TITLE
Add button dropdowns to edit styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.54",
+  "version": "0.9.55",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/TextButton/textButtonManifest.json
+++ b/src/TextButton/textButtonManifest.json
@@ -18,7 +18,8 @@
           { "label": "Outlined Button", "value": "outlined" },
           { "label": "Contained Button", "value": "contained" }
         ]
-      }
+      },
+      "style": true
     },
     {
       "name": "text",
@@ -51,7 +52,8 @@
           { "label": "Small", "value": "small" },
           { "label": "Extra small", "value": "extraSmall" }
         ]
-      }
+      },
+      "style": true
     },
     {
       "name": "primaryColor",


### PR DESCRIPTION
## Problem
We want the dropdowns to be in the new "Edit Styles" menu.

## Solution
Set the `style` prop for both dropdowns.
<img width="353" alt="expanded-button-styles" src="https://github.com/AdaloHQ/material-components-library/assets/46685700/26afa06e-f668-4d2d-8ddf-636731cd871a">
