### PR TITLE
Fix: List Empty States

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.62",
+  "version": "0.9.63",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.61",
+  "version": "0.9.62",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/Shared/EmptyState.js
+++ b/src/Shared/EmptyState.js
@@ -1,8 +1,31 @@
 import React, { Component } from 'react'
 import { View, Text, StyleSheet, Image } from 'react-native'
-import Icon from 'react-native-vector-icons/dist/MaterialIcons'
 
 import WrappedTextButton from '../TextButton/TextButton.js'
+
+const getButtonMargin = (buttonType, textTitleDisplay, emptyStateImageStatus) => {
+  if (buttonType === 'noButton') {
+    return 0
+  }
+
+  if (textTitleDisplay === 'noText' && emptyStateImageStatus === 'noImage') {
+    return 0
+  }
+
+  return 32
+}
+
+const getImageSource = imageSource => {
+  if (!imageSource) {
+    return require('./sqr-empty-state.png')
+  }
+
+  if (typeof imageSource === 'object' && typeof imageSource.value === 'object') {
+    return imageSource.value
+  }
+
+  return imageSource
+}
 
 export default class EmptyListWrapper extends Component {
   static defaultProps = {
@@ -54,19 +77,13 @@ export default class EmptyListWrapper extends Component {
         : {}
 
     const buttonMargin = {
-      marginTop:
-        buttonType !== 'noButton' &&
-        textTitleDisplay !== 'noText' &&
-        emptyStateImageStatus !== 'noImage'
-          ? 32
-          : 0,
+      marginTop: getButtonMargin(buttonType, textTitleDisplay, emptyStateImageStatus),
     }
 
-    const wrapperStyles =
-      emptyStateImageStatus === 'noImage' ? {} : styles.wrapper
+    const wrapperStyles = emptyStateImageStatus === 'noImage' ? {} : styles.wrapper
 
     return (
-      <View style={[wrapperStyles]}>
+      <View style={wrapperStyles}>
         <ImageHolder {...this.props} />
         {buttonType && buttonType !== 'noButton' && (
           <View style={{ alignItems: 'center' }}>
@@ -103,9 +120,9 @@ function ImageHolder(props) {
     imageHeight,
     imageRounding,
   } = props
-  let realImageSource = !imageSource
-    ? require('./sqr-empty-state.png')
-    : imageSource
+  let realImageSource = getImageSource(imageSource)
+
+  console.log('empty', props)
 
   const imageWrapperSize = { width: imageWidth, height: imageHeight }
 

--- a/src/Shared/EmptyState.js
+++ b/src/Shared/EmptyState.js
@@ -122,8 +122,6 @@ function ImageHolder(props) {
   } = props
   let realImageSource = getImageSource(imageSource)
 
-  console.log('empty', props)
-
   const imageWrapperSize = { width: imageWidth, height: imageHeight }
 
   if (!emptyStateImageStatus || emptyStateImageStatus === 'noImage') {


### PR DESCRIPTION
## Problem

When there's no Empty State image, there is no gap between text elements and the button element.

## Solution

Ensure when there's no button, that a margin is applied to create a gap between the text elements and the button element.

Note; when there's an Image specified, that some extra margin is applied to the top and bottom of the Empty State component.  When there's no image, there's no extra margin applied.  This is existing behaviour that I opted to leave as-is to avoid creating unexpected gaps in maker's layouts.

This also fixes a secondary issue where the image wasn't showing in Builder.

<img width="320" alt="Screenshot 2024-09-05 at 19 12 44" src="https://github.com/user-attachments/assets/ab22b437-24ca-4b89-89f5-9118041a6871">
<img width="320" alt="Screenshot 2024-09-05 at 19 12 28" src="https://github.com/user-attachments/assets/768a12ee-c537-4386-98c2-b11ff9207372">
<img width="320" alt="Screenshot 2024-09-05 at 19 12 05" src="https://github.com/user-attachments/assets/541b10b1-d880-4d58-be56-4565c35b58aa">
<img width="320" alt="Screenshot 2024-09-05 at 19 11 40" src="https://github.com/user-attachments/assets/99ca1edf-33d1-4ee3-ac79-844ce856e8ba">
<img width="320" alt="Screenshot 2024-09-05 at 19 11 16" src="https://github.com/user-attachments/assets/24c13ec8-3394-4b4d-ad45-3e0e8884a37d">
<img width="320" alt="Screenshot 2024-09-05 at 19 10 59" src="https://github.com/user-attachments/assets/61c067f7-cbcd-4365-96dc-43530f7048c7">
<img width="320" alt="Screenshot 2024-09-05 at 19 10 36" src="https://github.com/user-attachments/assets/966cc79f-c90b-4e90-8b39-18593f1f4a81">
<img width="320" alt="Screenshot 2024-09-05 at 19 10 14" src="https://github.com/user-attachments/assets/8c7abedb-5cbd-45f7-ae51-313ff6ada378">
