### PR TITLE
Add custom icons to material components library

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "style-loader": "^0.23.1"
   },
   "dependencies": {
-    "@protonapp/react-native-material-ui": "^2.0.8",
+    "@protonapp/react-native-material-ui": "^2.0.9",
     "@react-native-community/blur": "4.0.0",
     "chroma-js": "^2.1.2",
     "color": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.64",
+  "version": "0.9.65",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {
@@ -41,7 +41,7 @@
     "style-loader": "^0.23.1"
   },
   "dependencies": {
-    "@protonapp/react-native-material-ui": "^2.0.7",
+    "@protonapp/react-native-material-ui": "^2.0.8",
     "@react-native-community/blur": "4.0.0",
     "chroma-js": "^2.1.2",
     "color": "^3.1.0",

--- a/src/ActionButton/ActionButton.js
+++ b/src/ActionButton/ActionButton.js
@@ -56,11 +56,9 @@ export default class WrappedActionButton extends Component {
       _width,
       buttonType,
       resizeMethod,
-      getFlags,
     } = this.props
     const { width, isLoading } = this.state
-    const { hasUpdatedLoadingStates } = (getFlags && getFlags()) || {}
-    const onPressAction = hasUpdatedLoadingStates ? this.clickAction : action
+    const onPressAction = this.clickAction
 
     const containerStyles = {
       backgroundColor,

--- a/src/ActionButton/manifest.json
+++ b/src/ActionButton/manifest.json
@@ -30,6 +30,7 @@
       "name": "icon",
       "displayName": "Icon",
       "type": "icon",
+      "customIcons": true,
       "default": "add"
     },
     {

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -126,13 +126,11 @@ export default class AppBar extends Component {
       [propName]: { icon, enabled, action, iconType },
       color,
       editor,
-      getFlags,
     } = this.props
 
     const { loadingComponents } = this.state
-    const { hasUpdatedLoadingStates } = (getFlags && getFlags()) || {}
 
-    const onPressAction = hasUpdatedLoadingStates ? this.iconClickAction(action, propName) : action
+    const onPressAction = this.iconClickAction(action, propName)
 
     if (!enabled) {
       return null

--- a/src/AppBar/manifest.json
+++ b/src/AppBar/manifest.json
@@ -114,6 +114,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "arrow-back"
         },
         {
@@ -217,6 +218,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "favorite",
           "enabled": {
             "iconType": ["toggle", "ADALO_INTERNAL_!previous"]
@@ -248,6 +250,7 @@
           "name": "activeIcon",
           "displayName": "Active Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box",
           "enabled": {
             "iconType": "toggle"
@@ -266,6 +269,7 @@
           "name": "inactiveIcon",
           "displayName": "Inactive Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box-outline-blank",
           "enabled": {
             "iconType": "toggle"
@@ -320,6 +324,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "search",
           "enabled": {
             "iconType": ["toggle", "ADALO_INTERNAL_!previous"]
@@ -351,6 +356,7 @@
           "name": "activeIcon",
           "displayName": "Active Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box",
           "enabled": {
             "iconType": "toggle"
@@ -369,6 +375,7 @@
           "name": "inactiveIcon",
           "displayName": "Inactive Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box-outline-blank",
           "enabled": {
             "iconType": "toggle"

--- a/src/AvatarList/index.js
+++ b/src/AvatarList/index.js
@@ -43,10 +43,7 @@ class AvatarList extends Component {
       _fonts,
       listEmptyState,
       openAccordion,
-      getFlags,
     } = this.props
-
-    const { hasUpdatedLoadingStates } = (getFlags && getFlags()) || {}
 
     const renderEmptyState =
       (imageList && !imageList[0]) ||
@@ -72,15 +69,11 @@ class AvatarList extends Component {
       typeof navigator.userAgent === undefined ||
       (!imageList[0] && !listEmptyState)
     ) {
-      if (hasUpdatedLoadingStates) {
-        return (
-          <View style={{ height: imageSize, justifyContent: 'center' }}>
-            <ActivityIndicator color="#999999" />
-          </View>
-        )
-      } else {
-        return <View style={{ height: imageSize }}></View>
-      }
+      return (
+        <View style={{ height: imageSize, justifyContent: 'center' }}>
+          <ActivityIndicator color="#999999" />
+        </View>
+      )
     }
 
     const edit = this.props.editor

--- a/src/AvatarList/manifest.json
+++ b/src/AvatarList/manifest.json
@@ -247,6 +247,7 @@
           "name": "buttonIcon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "add",
           "enabled": {
             "buttonType": ["text", "outlined", "contained"]

--- a/src/CardList/index.js
+++ b/src/CardList/index.js
@@ -155,28 +155,16 @@ export default class ImageList extends Component {
   }
 
   render() {
-    let {
-      cardLayout,
-      searchBar,
-      items,
-      listEmptyState,
-      openAccordion,
-      getFlags,
-    } = this.props
+    let { cardLayout, searchBar, items, listEmptyState, openAccordion } =
+      this.props
     let wrap = [styles.wrap]
 
-    const { hasUpdatedLoadingStates } = (getFlags && getFlags()) || {}
-
     if (!items) {
-      if (hasUpdatedLoadingStates) {
-        return (
-          <View style={{ height: 260, justifyContent: 'center' }}>
-            <ActivityIndicator color="#999999" />
-          </View>
-        )
-      } else {
-        return <View></View>
-      }
+      return (
+        <View style={{ height: 260, justifyContent: 'center' }}>
+          <ActivityIndicator color="#999999" />
+        </View>
+      )
     }
 
     const newItems = this.filterItems(items)

--- a/src/CardList/manifest.json
+++ b/src/CardList/manifest.json
@@ -430,6 +430,7 @@
         {
           "name": "icon",
           "type": "icon",
+          "customIcons": true,
           "default": "favorite",
           "enabled": {
             "iconType": ["toggle", "ADALO_INTERNAL_!previous"]
@@ -465,6 +466,7 @@
           "name": "activeIcon",
           "displayName": "Active Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box",
           "enabled": {
             "iconType": "toggle"
@@ -483,6 +485,7 @@
           "name": "inactiveIcon",
           "displayName": "Inactive Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box-outline-blank",
           "enabled": {
             "iconType": "toggle"
@@ -542,6 +545,7 @@
         {
           "name": "icon",
           "type": "icon",
+          "customIcons": true,
           "default": "share",
           "enabled": {
             "iconType": ["toggle", "ADALO_INTERNAL_!previous"]
@@ -577,6 +581,7 @@
           "name": "activeIcon",
           "displayName": "Active Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box",
           "enabled": {
             "iconType": "toggle"
@@ -595,6 +600,7 @@
           "name": "inactiveIcon",
           "displayName": "Inactive Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box-outline-blank",
           "enabled": {
             "iconType": "toggle"
@@ -682,6 +688,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "search",
           "enabled": {
             "customStyles": "custom",
@@ -871,6 +878,7 @@
           "name": "buttonIcon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "add",
           "enabled": {
             "buttonType": ["text", "outlined", "contained"]

--- a/src/ChipList/index.js
+++ b/src/ChipList/index.js
@@ -46,25 +46,18 @@ class ChipList extends Component {
       _fonts,
       listEmptyState,
       openAccordion,
-      getFlags,
     } = this.props
-
-    const { hasUpdatedLoadingStates } = (getFlags && getFlags()) || {}
 
     if (
       !imageList ||
       typeof navigator.userAgent === undefined ||
       (!imageList[0] && !listEmptyState)
     ) {
-      if (hasUpdatedLoadingStates) {
-        return (
-          <View style={{ height: 32, justifyContent: 'center' }}>
-            <ActivityIndicator color="#999999" />
-          </View>
-        )
-      } else {
-        return <View style={{ height: 32 }}></View>
-      }
+      return (
+        <View style={{ height: 32, justifyContent: 'center' }}>
+          <ActivityIndicator color="#999999" />
+        </View>
+      )
     }
 
     const renderEmptyState =

--- a/src/ChipList/manifest.json
+++ b/src/ChipList/manifest.json
@@ -85,6 +85,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "cancel"
         },
 
@@ -264,6 +265,7 @@
           "name": "buttonIcon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "add",
           "enabled": {
             "buttonType": ["text", "outlined", "contained"]

--- a/src/HorizontalImageList/index.js
+++ b/src/HorizontalImageList/index.js
@@ -80,10 +80,7 @@ class HorizontalImageList extends Component {
       _fonts,
       listEmptyState,
       openAccordion,
-      getFlags,
     } = this.props
-
-    const { hasUpdatedLoadingStates } = (getFlags && getFlags()) || {}
 
     const renderEmptyState =
       (imageList && !imageList[0]) ||
@@ -100,15 +97,11 @@ class HorizontalImageList extends Component {
       typeof navigator.userAgent === undefined ||
       (!imageList[0] && !listEmptyState)
     ) {
-      if (hasUpdatedLoadingStates) {
-        return (
-          <View style={{ height: imageSize, justifyContent: 'center' }}>
-            <ActivityIndicator color="#999999" />
-          </View>
-        )
-      } else {
-        return <View style={{ height: imageSize }}></View>
-      }
+      return (
+        <View style={{ height: imageSize, justifyContent: 'center' }}>
+          <ActivityIndicator color="#999999" />
+        </View>
+      )
     }
 
     const {

--- a/src/HorizontalImageList/manifest.json
+++ b/src/HorizontalImageList/manifest.json
@@ -186,6 +186,7 @@
           "name": "trIcon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "more-vert",
           "enabled": {
             "tr": true
@@ -223,6 +224,7 @@
           "name": "tlIcon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "more-vert",
           "enabled": {
             "textPos": 0,
@@ -264,6 +266,7 @@
           "name": "tlIcon2",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "more-vert",
           "enabled": {
             "textSwitch": false,
@@ -299,6 +302,7 @@
           "name": "brIcon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "more-vert",
           "enabled": {
             "br": true
@@ -336,6 +340,7 @@
           "name": "blIcon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "more-vert",
           "enabled": {
             "bl": true,
@@ -378,6 +383,7 @@
           "name": "blIcon2",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "more-vert",
           "enabled": {
             "bl2": true,
@@ -574,6 +580,7 @@
           "name": "iconL",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "more-vert",
           "enabled": {
             "leftButton": true,
@@ -613,6 +620,7 @@
           "name": "activeIconL",
           "displayName": "Active Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box",
           "enabled": {
             "leftButton": true,
@@ -633,6 +641,7 @@
           "name": "inactiveIconL",
           "displayName": "Inactive Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box-outline-blank",
           "enabled": {
             "leftButton": true,
@@ -775,6 +784,7 @@
           "name": "iconR",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "more-vert",
           "enabled": {
             "rightButton": true,
@@ -814,6 +824,7 @@
           "name": "activeIconR",
           "displayName": "Active Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box",
           "enabled": {
             "rightButton": true,
@@ -834,6 +845,7 @@
           "name": "inactiveIconR",
           "displayName": "Inactive Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box-outline-blank",
           "enabled": {
             "rightButton": true,
@@ -1021,6 +1033,7 @@
           "name": "buttonIcon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "add",
           "enabled": {
             "buttonType": ["text", "outlined", "contained"]

--- a/src/Icon/index.js
+++ b/src/Icon/index.js
@@ -30,9 +30,8 @@ export default class WrappedIconToggle extends Component {
 
 
   render() {
-    const { iconName, iconColor, onPress, iconSize = 24, getFlags } = this.props
+    const { iconName, iconColor, onPress, iconSize = 24 } = this.props
     const { isLoading } = this.state
-    const { hasUpdatedLoadingStates } = (getFlags && getFlags()) || {}
 
     const styles = {
       wrapper: {
@@ -57,7 +56,7 @@ export default class WrappedIconToggle extends Component {
       )
     }
 
-    const onPressAction = hasUpdatedLoadingStates ? this.clickAction : onPress
+    const onPressAction = this.clickAction
 
     if (isLoading) {
       let spinnerSize = 'small'

--- a/src/Icon/manifest.json
+++ b/src/Icon/manifest.json
@@ -11,6 +11,7 @@
       "name": "iconName",
       "displayName": "Icon",
       "type": "icon",
+      "customIcons": true,
       "default": "chevron-right"
     },
     {

--- a/src/IconToggle/manifest.json
+++ b/src/IconToggle/manifest.json
@@ -17,6 +17,7 @@
       "name": "activeIcon",
       "displayName": "Active Icon",
       "type": "icon",
+      "customIcons": true,
       "default": "check-box"
     },
     {
@@ -29,6 +30,7 @@
       "name": "inactiveIcon",
       "displayName": "Inactive Icon",
       "type": "icon",
+      "customIcons": true,
       "default": "check-box-outline-blank"
     },
     {

--- a/src/ImageList/index.js
+++ b/src/ImageList/index.js
@@ -1,10 +1,5 @@
 import React, { Component } from 'react'
-import {
-  View,
-  Text,
-  StyleSheet,
-  ActivityIndicator,
-} from 'react-native'
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native'
 import { RippleFeedback, IconToggle } from '@protonapp/react-native-material-ui'
 import Gradient from './gradient'
 import SearchBarWrapper from '../Shared/SearchWrapper'
@@ -163,30 +158,21 @@ export default class ImageList extends Component {
       openAccordion,
       columnCount,
       _height,
-      getFlags,
     } = this.props
-
-    const { hasUpdatedLoadingStates } = (getFlags && getFlags()) || {}
 
     let layout = 'grid' //items[0] ? items[0].imageStyles.layout : 'grid'
 
     if (!items) {
-      if (hasUpdatedLoadingStates) {
-        // TODO (michael-adalo): flag is now set to ON for all environments,
-        // we could remove the check and default to the logic below
-        const height = columnCount === 2 ? _height / 2 : _height
+      const height = columnCount === 2 ? _height / 2 : _height
 
-        return (
-          <View
-            style={{ height, justifyContent: 'center' }}
-            onLayout={this.handleLayout}
-          >
-            <ActivityIndicator color="#999999" />
-          </View>
-        )
-      } else {
-        return <View></View>
-      }
+      return (
+        <View
+          style={{ height, justifyContent: 'center' }}
+          onLayout={this.handleLayout}
+        >
+          <ActivityIndicator color="#999999" />
+        </View>
+      )
     }
 
     const newItems = this.filterItems(items)
@@ -434,7 +420,7 @@ class Cell extends Component {
 
       if (!isEditor) {
         // Need to return at least one child, can't return null
-        return <React.Fragment/>
+        return <React.Fragment />
       }
     }
 

--- a/src/ImageList/manifest.json
+++ b/src/ImageList/manifest.json
@@ -202,6 +202,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "more-vert",
           "enabled": {
             "iconType": ["toggle", "ADALO_INTERNAL_!previous"]
@@ -250,6 +251,7 @@
           "name": "activeIcon",
           "displayName": "Active Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box",
           "enabled": {
             "iconType": "toggle"
@@ -268,6 +270,7 @@
           "name": "inactiveIcon",
           "displayName": "Inactive Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box-outline-blank",
           "enabled": {
             "iconType": "toggle"
@@ -360,6 +363,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "search",
           "enabled": {
             "customStyles": "custom",
@@ -549,6 +553,7 @@
           "name": "buttonIcon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "add",
           "enabled": {
             "buttonType": ["text", "outlined", "contained"]

--- a/src/SimpleList/index.js
+++ b/src/SimpleList/index.js
@@ -88,21 +88,14 @@ export default class SimpleList extends Component {
       searchBar,
       listEmptyState,
       openAccordion,
-      getFlags,
     } = this.props
 
-    const { hasUpdatedLoadingStates } = (getFlags && getFlags()) || {}
-
     if (!items) {
-      if (hasUpdatedLoadingStates) {
-        return (
-          <View style={styles.iconWrap}>
-            <ActivityIndicator color="#999999" />
-          </View>
-        )
-      } else {
-        return <View></View>
-      }
+      return (
+        <View style={styles.iconWrap}>
+          <ActivityIndicator color="#999999" />
+        </View>
+      )
     }
 
     let wrap = [styles.wrapper]

--- a/src/SimpleList/manifest.json
+++ b/src/SimpleList/manifest.json
@@ -138,6 +138,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "add",
           "enabled": { "type": "icon" }
         },
@@ -192,6 +193,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "add",
           "enabled": {
             "iconType": ["toggle", "ADALO_INTERNAL_!previous"]
@@ -229,6 +231,7 @@
           "name": "activeIcon",
           "displayName": "Active Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box",
           "enabled": {
             "iconType": "toggle"
@@ -247,6 +250,7 @@
           "name": "inactiveIcon",
           "displayName": "Inactive Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "check-box-outline-blank",
           "enabled": {
             "iconType": "toggle"
@@ -404,6 +408,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "search",
           "enabled": {
             "customStyles": "custom",
@@ -593,6 +598,7 @@
           "name": "buttonIcon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "add",
           "enabled": {
             "buttonType": ["text", "outlined", "contained"]

--- a/src/TabNavigator/index.js
+++ b/src/TabNavigator/index.js
@@ -38,8 +38,7 @@ export default class TabNavigator extends Component {
   }
 
   render() {
-    let { backgroundColor, editor, activeTab, _fonts, getFlags } = this.props
-    const { hasUpdatedLoadingStates } = (getFlags && getFlags()) || {}
+    let { backgroundColor, editor, activeTab, _fonts } = this.props
 
     let enabledTabs = tabNames.filter((tabName) => {
       let tab = this.props[tabName]
@@ -68,7 +67,7 @@ export default class TabNavigator extends Component {
         >
           {enabledTabs.map((tabName) => (
             <BottomNavigation.Action
-              showLoadingState={hasUpdatedLoadingStates}
+              showLoadingState
               key={tabName}
               icon={tabs[tabName].icon}
               label={tabs[tabName].label}

--- a/src/TabNavigator/manifest.json
+++ b/src/TabNavigator/manifest.json
@@ -64,6 +64,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "home"
         },
         {
@@ -93,6 +94,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "search"
         },
         {
@@ -127,6 +129,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "people"
         },
         {
@@ -161,6 +164,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "account-circle"
         },
         {
@@ -195,6 +199,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "more-horiz"
         },
         {

--- a/src/TextButton/textButtonManifest.json
+++ b/src/TextButton/textButtonManifest.json
@@ -37,6 +37,7 @@
       "name": "icon",
       "displayName": "Icon",
       "type": "icon",
+      "customIcons": true,
       "default": "add"
     },
     {
@@ -211,6 +212,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "add"
         },
         {
@@ -387,6 +389,7 @@
           "name": "icon",
           "displayName": "Icon",
           "type": "icon",
+          "customIcons": true,
           "default": "add"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2476,10 +2476,10 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@protonapp/react-native-material-ui@^2.0.8":
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/@protonapp/react-native-material-ui/-/react-native-material-ui-2.0.8.tgz#efee31a1f3d53d801b6265e11f682b0635f995d0"
-  integrity sha512-C7VDGzc8eEj80IcXOttIBA5KnPwEZnBN+2eqrZttnNkAYgeT7F1fM7vrB8C59bbCWGgAGLyeMQEFY0lUzrajSw==
+"@protonapp/react-native-material-ui@^2.0.9":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@protonapp/react-native-material-ui/-/react-native-material-ui-2.0.9.tgz#f569626d0608b0c35200cddba1c585156fc40020"
+  integrity sha512-ty3hmhJIqsBd4rz8Qt2pQcpkACtEcYwio/JDLBfZgZQKLOF0r0Ckmgyc+l8wTzrfLp1uFEAM76V2NMjZ8RzBPA==
   dependencies:
     color "3.1.0"
     hoist-non-react-statics "^2.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2476,10 +2476,10 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@protonapp/react-native-material-ui@^2.0.7":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@protonapp/react-native-material-ui/-/react-native-material-ui-2.0.7.tgz#2edf2b4792d2d119773381a07931716ac7fa674b"
-  integrity sha512-9ifSLFvmUb6EM5ph+/MsTQmq239S87szVoKpFfQ7O8MKdkRRzaxEY1T0sVStgWWPWc9VuCBBepgNWBNcfnaThg==
+"@protonapp/react-native-material-ui@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@protonapp/react-native-material-ui/-/react-native-material-ui-2.0.8.tgz#efee31a1f3d53d801b6265e11f682b0635f995d0"
+  integrity sha512-C7VDGzc8eEj80IcXOttIBA5KnPwEZnBN+2eqrZttnNkAYgeT7F1fM7vrB8C59bbCWGgAGLyeMQEFY0lUzrajSw==
   dependencies:
     color "3.1.0"
     hoist-non-react-statics "^2.5.5"
@@ -10816,7 +10816,7 @@ streamx@^2.15.0:
   optionalDependencies:
     bare-events "^2.2.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10842,15 +10842,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
@@ -10951,7 +10942,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10985,13 +10976,6 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -11894,16 +11878,7 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Problem
We want to add custom icons

## Solution
Add support for custom icons by updating the library that handles icons and updating manifest to indicate custom icons are supported.

## Related PRs
https://github.com/AdaloHQ/packager/pull/531
https://github.com/AdaloHQ/backend/pull/1501
https://github.com/AdaloHQ/frontend/pull/3075
https://github.com/AdaloHQ/star-rating-component/pull/3
https://github.com/AdaloHQ/react-native-material-ui/pull/3
https://github.com/AdaloHQ/runner/pull/991
https://github.com/AdaloHQ/stopwatch/pull/38