### PR TITLE
Add button background gradient support (RN 0.77.2)

### DIFF
--- a/src/Shared/gradientStyle.js
+++ b/src/Shared/gradientStyle.js
@@ -1,0 +1,10 @@
+import { Platform } from 'react-native'
+
+export const getGradientStyle = (gradientCSS) => {
+  if (!gradientCSS) return {}
+
+  return Platform.select({
+    web: { backgroundImage: gradientCSS },
+    default: { experimental_backgroundImage: gradientCSS },
+  })
+}

--- a/src/TextButton/TextButton.js
+++ b/src/TextButton/TextButton.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { View, StyleSheet, ActivityIndicator } from 'react-native'
 import color from 'color'
 import { Button } from '@protonapp/react-native-material-ui'
+import { getGradientStyle } from '../Shared/gradientStyle'
 
 import '../Shared/icons'
 
@@ -32,6 +33,15 @@ export default class WrappedTextButton extends Component {
     hovering: false,
   }
 
+  getGradientCSS(backgroundGradient) {
+    const { type, startColor, endColor, angle = 180 } = backgroundGradient
+    if (!startColor || !endColor) return undefined
+
+    return type === 'radial'
+      ? `radial-gradient(circle, ${startColor}, ${endColor})`
+      : `linear-gradient(${angle}deg, ${startColor}, ${endColor})`
+  }
+
   getContainerStyles() {
     const defaults = this.props
     const {
@@ -45,8 +55,10 @@ export default class WrappedTextButton extends Component {
       border = {},
       advancedShadow = {},
       hover = false,
+      backgroundGradient,
     } = this.getButtonState()
     const { hovering } = this.state
+    const isGradientEnabled = backgroundGradient?.enabled === true
 
     const containerStyles = SIZE_PROPERTIES.has(sizing)
       ? {
@@ -61,12 +73,17 @@ export default class WrappedTextButton extends Component {
 
     if (type === 'contained') {
       let backgroundColor = primaryColor
-      if (hover && hovering) {
+      let gradientStyle = {}
+      if (isGradientEnabled) {
+        backgroundColor = 'transparent'
+        gradientStyle = getGradientStyle(this.getGradientCSS(backgroundGradient))
+      } else if (hover && hovering) {
         backgroundColor = this.getHoverColor()
       }
       return {
         ...containerStyles,
         backgroundColor,
+        ...gradientStyle,
         borderRadius,
       }
     }
@@ -91,7 +108,11 @@ export default class WrappedTextButton extends Component {
       }
 
       let backgroundColor = primaryColor
-      if (hover && hovering) {
+      let gradientStyle = {}
+      if (isGradientEnabled) {
+        backgroundColor = 'transparent'
+        gradientStyle = getGradientStyle(this.getGradientCSS(backgroundGradient))
+      } else if (hover && hovering) {
         backgroundColor = this.getHoverColor()
       }
 
@@ -100,6 +121,7 @@ export default class WrappedTextButton extends Component {
         ...borderStyles,
         ...shadowStyles,
         backgroundColor,
+        ...gradientStyle,
         opacity: opacity / 100,
         borderRadius,
       }


### PR DESCRIPTION
## Summary
- Adds background gradient rendering for Button component (contained and custom types)
- Uses React Native's built-in `experimental_backgroundImage` style property (native) and `backgroundImage` (web) — no additional native dependencies
- Shared `getGradientStyle()` utility in `src/Shared/gradientStyle.js` handles platform differences
- Supports both linear and radial gradients

## Files changed
- `src/TextButton/TextButton.js` — gradient CSS generation + container style application
- `src/Shared/gradientStyle.js` — new shared utility for cross-platform gradient styles

## Test plan
- [ ] Verify button gradient renders correctly in web preview (localhost:3001)
- [ ] Verify button gradient renders correctly in editor (localhost:3000)
- [ ] Verify gradient direction matches between editor and preview
- [ ] Verify buttons without gradient enabled are unaffected
- [ ] Build Android app and verify gradient renders on native
- [ ] Build iOS app and verify gradient renders on native
- [ ] Verify existing components (ImageList, AppBar, HorizontalImageList) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)