### PR TITLE
Add button background gradient support (RN 0.77.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/Shared/gradientStyle.js
+++ b/src/Shared/gradientStyle.js
@@ -1,0 +1,10 @@
+import { Platform } from 'react-native'
+
+export const getGradientStyle = (gradientCSS) => {
+  if (!gradientCSS) return {}
+
+  return Platform.select({
+    web: { backgroundImage: gradientCSS },
+    default: { experimental_backgroundImage: gradientCSS },
+  })
+}

--- a/src/TextButton/TextButton.js
+++ b/src/TextButton/TextButton.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { View, StyleSheet, ActivityIndicator } from 'react-native'
 import color from 'color'
 import { Button } from '@protonapp/react-native-material-ui'
+import { getGradientStyle } from '../Shared/gradientStyle'
 
 import '../Shared/icons'
 
@@ -32,6 +33,15 @@ export default class WrappedTextButton extends Component {
     hovering: false,
   }
 
+  getGradientCSS(backgroundGradient) {
+    const { type, startColor, endColor, angle = 180 } = backgroundGradient
+    if (!startColor || !endColor) return undefined
+
+    return type === 'radial'
+      ? `radial-gradient(circle, ${startColor}, ${endColor})`
+      : `linear-gradient(${angle}deg, ${startColor}, ${endColor})`
+  }
+
   getContainerStyles() {
     const defaults = this.props
     const {
@@ -45,8 +55,10 @@ export default class WrappedTextButton extends Component {
       border = {},
       advancedShadow = {},
       hover = false,
+      backgroundGradient,
     } = this.getButtonState()
     const { hovering } = this.state
+    const isGradientEnabled = backgroundGradient?.enabled === true
 
     const containerStyles = SIZE_PROPERTIES.has(sizing)
       ? {
@@ -61,12 +73,17 @@ export default class WrappedTextButton extends Component {
 
     if (type === 'contained') {
       let backgroundColor = primaryColor
-      if (hover && hovering) {
+      let gradientStyle = {}
+      if (isGradientEnabled) {
+        backgroundColor = 'transparent'
+        gradientStyle = getGradientStyle(this.getGradientCSS(backgroundGradient))
+      } else if (hover && hovering) {
         backgroundColor = this.getHoverColor()
       }
       return {
         ...containerStyles,
         backgroundColor,
+        ...gradientStyle,
         borderRadius,
       }
     }
@@ -91,7 +108,11 @@ export default class WrappedTextButton extends Component {
       }
 
       let backgroundColor = primaryColor
-      if (hover && hovering) {
+      let gradientStyle = {}
+      if (isGradientEnabled) {
+        backgroundColor = 'transparent'
+        gradientStyle = getGradientStyle(this.getGradientCSS(backgroundGradient))
+      } else if (hover && hovering) {
         backgroundColor = this.getHoverColor()
       }
 
@@ -100,6 +121,7 @@ export default class WrappedTextButton extends Component {
         ...borderStyles,
         ...shadowStyles,
         backgroundColor,
+        ...gradientStyle,
         opacity: opacity / 100,
         borderRadius,
       }

--- a/src/TextButton/textButtonManifest.json
+++ b/src/TextButton/textButtonManifest.json
@@ -66,8 +66,23 @@
       "style": true
     },
     {
+      "name": "backgroundGradient",
+      "displayName": "Background Gradient",
+      "type": "object",
+      "default": {
+        "enabled": false,
+        "type": "linear",
+        "startColor": "@primary",
+        "endColor": "@secondary",
+        "angle": 180
+      },
+      "enabled": { "type": ["contained", "custom"] },
+      "style": true,
+      "hidden": true
+    },
+    {
       "name": "contrastColor",
-      "displayName": "Icon & Text Color",
+      "displayName": "Text & Icon Color",
       "type": "color",
       "default": "@contrast:primaryColor",
       "enabled": { "type": ["contained", "custom"] },
@@ -241,8 +256,23 @@
           "style": true
         },
         {
+          "name": "backgroundGradient",
+          "displayName": "Background Gradient",
+          "type": "object",
+          "default": {
+            "enabled": false,
+            "type": "linear",
+            "startColor": "@primary",
+            "endColor": "@secondary",
+            "angle": 180
+          },
+          "enabled": { "type": ["contained", "custom"] },
+          "style": true,
+          "hidden": true
+        },
+        {
           "name": "contrastColor",
-          "displayName": "Icon & Text Color",
+          "displayName": "Text & Icon Color",
           "type": "color",
           "default": "@contrast:primaryColor",
           "enabled": { "type": ["contained", "custom"] },
@@ -418,8 +448,23 @@
           "style": true
         },
         {
+          "name": "backgroundGradient",
+          "displayName": "Background Gradient",
+          "type": "object",
+          "default": {
+            "enabled": false,
+            "type": "linear",
+            "startColor": "@primary",
+            "endColor": "@secondary",
+            "angle": 180
+          },
+          "enabled": { "type": ["contained", "custom"] },
+          "style": true,
+          "hidden": true
+        },
+        {
           "name": "contrastColor",
-          "displayName": "Icon & Text Color",
+          "displayName": "Text & Icon Color",
           "type": "color",
           "default": "@contrast:primaryColor",
           "enabled": { "type": ["contained", "custom"] },


### PR DESCRIPTION
## Summary
- Add `backgroundGradient` prop to Button manifest (main props + both additional states)
- Add `gradientStyle.js` helper using `backgroundImage` (web) / `experimental_backgroundImage` (native)
- Apply gradient in `getContainerStyles()` for `contained` and `custom` button types
- Rename `contrastColor` displayName to "Text & Icon Color"

## ⚠️ Do NOT merge yet — waiting for review
**Do not push to this branch from VS Code** — it triggers auto-merge.

## Test plan
- [ ] Gradient renders on contained button type
- [ ] Gradient renders on custom button type
- [ ] Gradient disabled for text/outlined types
- [ ] Additional states 1 & 2 support gradient
- [ ] Test on web preview and native

🤖 Generated with [Claude Code](https://claude.com/claude-code)