### PR TITLE
Fix: fix screen shaking old RN

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.78",
+  "version": "0.9.80",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.80",
+  "version": "0.9.81",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {

--- a/src/CardList/index.js
+++ b/src/CardList/index.js
@@ -83,13 +83,17 @@ export default class ImageList extends Component {
 
     const columns = this.getColumns(items)
 
-    let wrap = [styles.wrapper]
+    let { fullWidth } = this.state
+    const cellWidth =
+      fullWidth > 0 ? Math.floor(fullWidth / this.getColumnCount()) - 8 : null
 
     return (
-      <View style={wrap}>
+      <View style={styles.wrapper} onLayout={this.handleLayout}>
         {columns.map((column, i) => (
           <View key={i} style={styles.column}>
-            {column.map((itm) => this.renderCell(itm, layout, editor, _fonts))}
+            {column.map((itm) =>
+              this.renderCell(itm, layout, editor, _fonts, cellWidth)
+            )}
           </View>
         ))}
       </View>
@@ -297,6 +301,13 @@ class Cell extends Component {
     const ratio =
       media.shape === 'square' ? 1 : media.shape === 'portrait' ? 1.5 : 2 / 3
 
+    const editorPadding =
+      media.shape === 'square'
+        ? '100%'
+        : media.shape === 'portrait'
+          ? '150%'
+          : '66.6667%'
+
     let imageStyles = []
 
     if (cardStyles) {
@@ -320,7 +331,10 @@ class Cell extends Component {
             source={source}
             style={[
               styles.image,
-              { height: Math.round(ratio * 80), borderRadius: 2 },
+              {
+                height: editor ? editorPadding : Math.round(ratio * 80),
+                borderRadius: 2,
+              },
               ...imageStyles,
             ]}
           />
@@ -336,10 +350,23 @@ class Cell extends Component {
       wrapperStyles.push(styles.middleMedia)
     }
 
+    if (editor) {
+      return (
+        <View style={wrapperStyles}>
+          <ImgixImage
+            resizeMode="cover"
+            source={source}
+            style={[styles.image, { paddingTop: editorPadding }, ...imageStyles]}
+          />
+        </View>
+      )
+    }
+
     return (
       <AspectMedia
         ratio={ratio}
         source={source}
+        width={this.props.width}
         wrapperStyle={wrapperStyles}
         imageStyle={imageStyles}
       />
@@ -677,49 +704,23 @@ class Actions extends Component {
   }
 }
 
-class AspectMedia extends Component {
-  state = { width: null }
+const AspectMedia = ({ ratio, source, width, wrapperStyle, imageStyle }) => {
+  const height = width > 0 ? Math.round(width * ratio) : undefined
 
-  handleLayout = ({ nativeEvent }) => {
-    const measured = (nativeEvent && nativeEvent.layout && nativeEvent.layout.width) || 0
-    const width = Math.round(measured)
-
-    if (width && width !== this.state.width) {
-      this.setState({ width })
-    }
-  }
-
-  render() {
-    const { ratio, source, wrapperStyle, imageStyle } = this.props
-    const { width } = this.state
-
-    const height = width ? Math.round(width * ratio) : undefined
-
-    return (
-      <View
-        onLayout={this.handleLayout}
-        style={[wrapperStyle, height ? { height } : null]}
-      >
-        {height ? (
-          <ImgixImage
-            resizeMode="cover"
-            source={source}
-            style={[styles.imageFill, imageStyle]}
-          />
-        ) : null}
-      </View>
-    )
-  }
+  return (
+    <View style={wrapperStyle}>
+      {height ? (
+        <ImgixImage
+          resizeMode="cover"
+          source={source}
+          style={[imageStyle, { width, height }]}
+        />
+      ) : null}
+    </View>
+  )
 }
 
 const styles = StyleSheet.create({
-  imageFill: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-  },
   gridWrap: {
     margin: 4,
     flexDirection: 'row',

--- a/src/CardList/index.js
+++ b/src/CardList/index.js
@@ -40,8 +40,14 @@ export default class ImageList extends Component {
     const { width } = (nativeEvent && nativeEvent.layout) || {}
     const { fullWidth: prevWidth } = this.state
 
-    if (width !== prevWidth) {
-      this.setState({ fullWidth: width })
+    // Round to an integer pixel before comparing/storing. The raw onLayout width
+    // is a float; a strict `!==` compare re-renders the whole list on sub-pixel
+    // noise, and a fractional width feeds fractional cell/media sizes that round
+    // inconsistently between passes (a source of the list "shaking").
+    const roundedWidth = Math.round(width || 0)
+
+    if (roundedWidth && roundedWidth !== prevWidth) {
+      this.setState({ fullWidth: roundedWidth })
     }
   }
   getColumns(items) {
@@ -97,7 +103,11 @@ export default class ImageList extends Component {
     let { layout, columnCount, editor, _fonts } = this.props
 
     let { fullWidth } = this.state
-    let width = fullWidth / columnCount - 8
+    // Integer cell width — a fractional width makes each card's height round
+    // inconsistently across layout passes, which accumulates into the list
+    // height oscillating ("shaking"). null until a real width is measured, so
+    // we never derive a NaN or negative width.
+    let width = fullWidth > 0 ? Math.floor(fullWidth / columnCount) - 8 : null
 
     return (
       <View onLayout={this.handleLayout} style={styles.gridWrap}>
@@ -291,23 +301,18 @@ class Cell extends Component {
     if (editor) {
       source = placeholder
     }
-    let percent =
-      media.shape === 'square'
-        ? '100%'
-        : media.shape === 'portrait'
-        ? '150%'
-        : '66.6667%'
-    let imageStyles = [{ paddingTop: percent }]
-    let wrapperStyles = [styles.mediaWrapper]
 
-    if (media.position === 'top') {
-      wrapperStyles.push(styles.topMedia)
-    } else if (media.position === 'right') {
-      wrapperStyles = [styles.rightMedia]
-      imageStyles = [{ height: percent, borderRadius: 2 }]
-    } else {
-      wrapperStyles.push(styles.middleMedia)
-    }
+    // Aspect ratio (height / width). Previously expressed as a CSS percentage
+    // (paddingTop) which RN resolves to a *fractional* pixel height; that
+    // fraction rounds up or down differently between layout passes and, summed
+    // over many cards, makes the whole list height oscillate ("shaking"). We
+    // instead measure the width and apply an explicit rounded integer height
+    // (see AspectMedia), so a card's height is deterministic.
+    const ratio =
+      media.shape === 'square' ? 1 : media.shape === 'portrait' ? 1.5 : 2 / 3
+
+    let imageStyles = []
+
     if (cardStyles) {
       if (!cardStyles.shadow && !cardStyles.background && !cardStyles.border) {
         imageStyles.push({
@@ -321,14 +326,39 @@ class Cell extends Component {
       imageStyles.push({ backgroundColor: '#ccc' })
     }
 
+    // Image on the right is a fixed 80x80 area, so its height is already a
+    // constant integer — no fractional aspect box involved.
+    if (media.position === 'right') {
+      return (
+        <View style={styles.rightMedia}>
+          <ImgixImage
+            resizeMode="cover"
+            source={source}
+            style={[
+              styles.image,
+              { height: Math.round(ratio * 80), borderRadius: 2 },
+              ...imageStyles,
+            ]}
+          />
+        </View>
+      )
+    }
+
+    const wrapperStyles = [styles.mediaWrapper]
+
+    if (media.position === 'top') {
+      wrapperStyles.push(styles.topMedia)
+    } else {
+      wrapperStyles.push(styles.middleMedia)
+    }
+
     return (
-      <View style={wrapperStyles}>
-        <ImgixImage
-          resizeMode="cover"
-          source={source}
-          style={[styles.image, imageStyles]}
-        />
-      </View>
+      <AspectMedia
+        ratio={ratio}
+        source={source}
+        wrapperStyle={wrapperStyles}
+        imageStyle={imageStyles}
+      />
     )
   }
 
@@ -663,7 +693,55 @@ class Actions extends Component {
   }
 }
 
+// Renders a media box whose height is an explicit, rounded integer derived from
+// its measured width (height = round(width * ratio)). This replaces the old
+// percentage paddingTop aspect box, whose fractional height rounded
+// inconsistently between layout passes and accumulated across cards into the
+// list "shaking". The measured width is rounded, so onLayout settles in one
+// pass instead of thrashing on sub-pixel changes.
+class AspectMedia extends Component {
+  state = { width: null }
+
+  handleLayout = ({ nativeEvent }) => {
+    const measured = (nativeEvent && nativeEvent.layout && nativeEvent.layout.width) || 0
+    const width = Math.round(measured)
+
+    if (width && width !== this.state.width) {
+      this.setState({ width })
+    }
+  }
+
+  render() {
+    const { ratio, source, wrapperStyle, imageStyle } = this.props
+    const { width } = this.state
+
+    const height = width ? Math.round(width * ratio) : undefined
+
+    return (
+      <View
+        onLayout={this.handleLayout}
+        style={[wrapperStyle, height ? { height } : null]}
+      >
+        {height ? (
+          <ImgixImage
+            resizeMode="cover"
+            source={source}
+            style={[styles.imageFill, imageStyle]}
+          />
+        ) : null}
+      </View>
+    )
+  }
+}
+
 const styles = StyleSheet.create({
+  imageFill: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
   gridWrap: {
     margin: 4,
     flexDirection: 'row',

--- a/src/CardList/index.js
+++ b/src/CardList/index.js
@@ -40,10 +40,6 @@ export default class ImageList extends Component {
     const { width } = (nativeEvent && nativeEvent.layout) || {}
     const { fullWidth: prevWidth } = this.state
 
-    // Round to an integer pixel before comparing/storing. The raw onLayout width
-    // is a float; a strict `!==` compare re-renders the whole list on sub-pixel
-    // noise, and a fractional width feeds fractional cell/media sizes that round
-    // inconsistently between passes (a source of the list "shaking").
     const roundedWidth = Math.round(width || 0)
 
     if (roundedWidth && roundedWidth !== prevWidth) {
@@ -103,10 +99,6 @@ export default class ImageList extends Component {
     let { layout, columnCount, editor, _fonts } = this.props
 
     let { fullWidth } = this.state
-    // Integer cell width — a fractional width makes each card's height round
-    // inconsistently across layout passes, which accumulates into the list
-    // height oscillating ("shaking"). null until a real width is measured, so
-    // we never derive a NaN or negative width.
     let width = fullWidth > 0 ? Math.floor(fullWidth / columnCount) - 8 : null
 
     return (
@@ -302,12 +294,6 @@ class Cell extends Component {
       source = placeholder
     }
 
-    // Aspect ratio (height / width). Previously expressed as a CSS percentage
-    // (paddingTop) which RN resolves to a *fractional* pixel height; that
-    // fraction rounds up or down differently between layout passes and, summed
-    // over many cards, makes the whole list height oscillate ("shaking"). We
-    // instead measure the width and apply an explicit rounded integer height
-    // (see AspectMedia), so a card's height is deterministic.
     const ratio =
       media.shape === 'square' ? 1 : media.shape === 'portrait' ? 1.5 : 2 / 3
 
@@ -326,8 +312,6 @@ class Cell extends Component {
       imageStyles.push({ backgroundColor: '#ccc' })
     }
 
-    // Image on the right is a fixed 80x80 area, so its height is already a
-    // constant integer — no fractional aspect box involved.
     if (media.position === 'right') {
       return (
         <View style={styles.rightMedia}>
@@ -693,12 +677,6 @@ class Actions extends Component {
   }
 }
 
-// Renders a media box whose height is an explicit, rounded integer derived from
-// its measured width (height = round(width * ratio)). This replaces the old
-// percentage paddingTop aspect box, whose fractional height rounded
-// inconsistently between layout passes and accumulated across cards into the
-// list "shaking". The measured width is rounded, so onLayout settles in one
-// pass instead of thrashing on sub-pixel changes.
 class AspectMedia extends Component {
   state = { width: null }
 

--- a/src/ImageList/index.js
+++ b/src/ImageList/index.js
@@ -19,8 +19,6 @@ export default class ImageList extends Component {
   renderGrid(items) {
     let { columnCount, _width, editor } = this.props
     let { fullWidth } = this.state
-    // Integer cell width — a fractional width makes each image's height round
-    // inconsistently across passes, accumulating into the list "shaking".
     let width = Math.floor((fullWidth || _width) / columnCount)
 
     return (
@@ -65,7 +63,6 @@ export default class ImageList extends Component {
 
     let columns = this.getColumns(items)
 
-    // Integer cell width (see renderGrid) — avoids fractional image heights.
     let width = Math.floor((fullWidth || _width) / columnCount)
 
     let wrap = [styles.wrapper]
@@ -93,10 +90,6 @@ export default class ImageList extends Component {
     const { width } = (nativeEvent && nativeEvent.layout) || {}
     const { fullWidth: prevWidth } = this.state
 
-    // Round to an integer pixel before comparing/storing. The raw onLayout
-    // width is a float; a strict `!==` compare re-renders on sub-pixel noise,
-    // and a fractional width feeds a fractional image height that rounds
-    // inconsistently between passes (a source of the list "shaking").
     const roundedWidth = Math.round(width || 0)
 
     if (roundedWidth && roundedWidth !== prevWidth) {
@@ -394,8 +387,6 @@ class Cell extends Component {
     if (!source) {
       imageStyling.push({ backgroundColor: '#ccc' })
     }
-    // Integer height in every shape so it can't carry a sub-pixel that rounds
-    // inconsistently between layout passes (landscape was already rounded).
     let shapeWidth = Math.round(width)
 
     if (imageStyles) {

--- a/src/ImageList/index.js
+++ b/src/ImageList/index.js
@@ -19,7 +19,9 @@ export default class ImageList extends Component {
   renderGrid(items) {
     let { columnCount, _width, editor } = this.props
     let { fullWidth } = this.state
-    let width = (fullWidth || _width) / columnCount
+    // Integer cell width — a fractional width makes each image's height round
+    // inconsistently across passes, accumulating into the list "shaking".
+    let width = Math.floor((fullWidth || _width) / columnCount)
 
     return (
       <View style={styles.wrapper}>
@@ -63,7 +65,8 @@ export default class ImageList extends Component {
 
     let columns = this.getColumns(items)
 
-    let width = (fullWidth || _width) / columnCount
+    // Integer cell width (see renderGrid) — avoids fractional image heights.
+    let width = Math.floor((fullWidth || _width) / columnCount)
 
     let wrap = [styles.wrapper]
 
@@ -90,8 +93,14 @@ export default class ImageList extends Component {
     const { width } = (nativeEvent && nativeEvent.layout) || {}
     const { fullWidth: prevWidth } = this.state
 
-    if (width !== prevWidth) {
-      this.setState({ fullWidth: width })
+    // Round to an integer pixel before comparing/storing. The raw onLayout
+    // width is a float; a strict `!==` compare re-renders on sub-pixel noise,
+    // and a fractional width feeds a fractional image height that rounds
+    // inconsistently between passes (a source of the list "shaking").
+    const roundedWidth = Math.round(width || 0)
+
+    if (roundedWidth && roundedWidth !== prevWidth) {
+      this.setState({ fullWidth: roundedWidth })
     }
   }
 
@@ -385,7 +394,9 @@ class Cell extends Component {
     if (!source) {
       imageStyling.push({ backgroundColor: '#ccc' })
     }
-    let shapeWidth = width
+    // Integer height in every shape so it can't carry a sub-pixel that rounds
+    // inconsistently between layout passes (landscape was already rounded).
+    let shapeWidth = Math.round(width)
 
     if (imageStyles) {
       if (imageStyles.rounding) {
@@ -393,7 +404,7 @@ class Cell extends Component {
       }
 
       if (imageStyles.shape === 'portrait') {
-        shapeWidth = width * 1.5
+        shapeWidth = Math.round(width * 1.5)
       } else if (imageStyles.shape === 'landscape') {
         shapeWidth = Math.round((width * 2) / 3)
       }


### PR DESCRIPTION
Defect:
Card List (full-width) shakes/jitters while scrolling — Android, responsive apps
https://trello.com/c/U05CkkOt

Solution :
make height calculation not via percentage but via ratio and round the result.