### PR TITLE
chore: bump version to 0.9.82

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.9.81",
+  "version": "0.9.82",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Version bump for the marketplace publish of the CDN host-gate fix ([#159](https://github.com/AdaloHQ/material-components-library/pull/159)). `npx adalo publish` (legacy RN) rejects a re-publish at the same version, so `main` must carry the new version before publishing.