### PR TITLE
chore: bump version to 0.10.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.10.24",
+  "version": "0.10.25",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Version bump for the marketplace publish of the CDN host-gate fix ([#160](https://github.com/AdaloHQ/material-components-library/pull/160)) on the new-RN branch. `npx adalo publish --new-react-native` rejects a re-publish at the same version, so `upgrade-rn` must carry the new version before publishing.