### PR TITLE
chore: bump version to 0.10.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/material-components",
-  "version": "0.10.25",
+  "version": "0.10.26",
   "description": "Material UI Components for Proton",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Re-bump for a corrected new-RN publish. 0.10.25 was published without `--new-react-native`, so it registered as a legacy build (empty RN-version column) instead of RN 0.77.2. The registry won't accept a re-publish at the same version, so bump to 0.10.26 and publish with `npx adalo publish --ignore-logo --new-react-native`. 0.10.25 stays pending/inactive — no maker impact.